### PR TITLE
The `document.body` can be undefined when using `toMatch`

### DIFF
--- a/packages/expect-puppeteer/src/matchers/notToMatch.js
+++ b/packages/expect-puppeteer/src/matchers/notToMatch.js
@@ -1,7 +1,7 @@
 async function notToMatch(page, matcher, options = { timeout: 500 }) {
   try {
     await page.waitForFunction(
-      `document.body.textContent.match(new RegExp('${matcher}')) === null`,
+      `document.body && document.body.textContent.match(new RegExp('${matcher}')) === null`,
       options,
     )
   } catch (error) {

--- a/packages/expect-puppeteer/src/matchers/toMatch.js
+++ b/packages/expect-puppeteer/src/matchers/toMatch.js
@@ -1,7 +1,7 @@
 async function toMatch(page, matcher, options = { timeout: 500 }) {
   try {
     await page.waitForFunction(
-      `document.body.textContent.match(new RegExp('${matcher}')) !== null`,
+      `document.body && document.body.textContent.match(new RegExp('${matcher}')) !== null`,
       options,
     )
   } catch (error) {


### PR DESCRIPTION
```
TypeError: Cannot read property 'textContent' of null
```

Also, thank you for finally making Jest with Puppeteer feasible. I tried setting this up a few times before and had a really hard time.