### PR TITLE
Add jest to npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Run your tests using Jest & Puppeteer 🎪✨
 
 ```
-npm install --save-dev jest-puppeteer puppeteer
+npm install --save-dev jest-puppeteer jest-environment-node puppeteer
 ```
 
 > TypeScript users should additionally install `@types/puppeteer` and `@types/jest-environment-puppeteer`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Run your tests using Jest & Puppeteer 🎪✨
 
 ```
-npm install --save-dev jest-puppeteer jest-environment-node puppeteer
+npm install --save-dev jest-puppeteer puppeteer jest
 ```
 
 > TypeScript users should additionally install `@types/puppeteer` and `@types/jest-environment-puppeteer`


### PR DESCRIPTION
This fixes the [fresh install problem](https://github.com/smooth-code/jest-puppeteer/issues/42#issuecomment-384057308).

The README.md assumes that jest is installed locally. If someone wants to try out jest-puppeteer in a new directory, jest won't be installed locally. To fix fresh install problem, one of these things need to happen:
- Remove peer dependencies (my ideal)
- Add jest-environment-node to jest-puppeteer command (this PR)
- Add jest to npm install command