### PR TITLE
Add incognito context support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   globals: {
     page: true,
     browser: true,
+    context:true,
     jestPuppeteer: true,
   },
   rules: {

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Other options are documented in [jest-dev-server](https://github.com/smooth-code
 
 ### Configure Puppeteer
 
-Jest Puppeteer automatically detect the best config to start Puppeteer but sometimes you may need to specify custom options. [All Puppeteer launch options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions) can be specified in `jest-puppeteer.config.js` at the root of the project. Since it is JavaScript, you can use all stuff you need, including environment.
+Jest Puppeteer automatically detect the best config to start Puppeteer but sometimes you may need to specify custom options. [All Puppeteer launch options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions) can be specified in `jest-puppeteer.config.js` at the root of the project. Since it is JavaScript, you can use all the stuff that you need, including environment.
+ 
+ The browser context can be also specified - `default` or `incognito` - if you want more isolation between running instances. More information available in [jest-puppeteer-environment readme](https://github.com/smooth-code/jest-puppeteer/blob/master/packages/jest-environment-puppeteer/README.md)
 
 ```js
 // jest-puppeteer.config.js
@@ -108,12 +110,13 @@ module.exports = {
     dumpio: true,
     headless: process.env.HEADLESS !== 'false',
   },
+  browserContext: 'default'
 }
 ```
 
 ### Configure ESLint
 
-Jest Puppeteer exposes two new globals: `browser`, `page`. If you want to avoid errors, you can add them to your `.eslintrc.js`:
+Jest Puppeteer exposes three new globals: `browser`, `page`, `context`. If you want to avoid errors, you can add them to your `.eslintrc.js`:
 
 ```js
 // .eslintrc.js
@@ -124,6 +127,7 @@ module.exports = {
   globals: {
     page: true,
     browser: true,
+    context: true,
     jestPuppeteer: true,
   },
 }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   launch: {
     headless: process.env.CI === 'true',
+    incognito: false,
   },
   server: {
     command: 'node server',

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   launch: {
     headless: process.env.CI === 'true',
-    incognito: false,
   },
+  browserContext: 'default',
   server: {
     command: 'node server',
     port: 4444,

--- a/packages/expect-puppeteer/src/options.js
+++ b/packages/expect-puppeteer/src/options.js
@@ -9,6 +9,7 @@ export const getDefaultOptions = () => {
     global.puppeteerConfig &&
     global.puppeteerConfig.launch &&
     global.puppeteerConfig.launch.slowMo &&
+    global.puppeteerConfig.browserContext &&
     defaultOptionsValue &&
     defaultOptionsValue.timeout
   ) {

--- a/packages/jest-environment-puppeteer/README.md
+++ b/packages/jest-environment-puppeteer/README.md
@@ -64,15 +64,7 @@ it('should fill an input', async () => {
 
 Give access to a [Browser context](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browsercontext) that is instanciated when the browser is launched.
 
-It is possible to set the browser context inside the config `jest-puppeteer-config.js` in the root of this project. The context will always be exposed via the global `context` object the same way `page` and `browser` are exposed. 
-
-Accepted values: 
-
-* `default` Default behavior, the browser will have one instance where all tabs share the same context.
-
-* `incognito` Forces each instance to have a separate, isolated context. Useful when running tests that could interfere with one another. 
-  * Example: testing multiple users on the same app at once with login, transactions, etc.  
-
+It is possible to set the browser context inside the config `jest-puppeteer-config.js` in the root of this project. The context will always be exposed via the global `context` object the same way `page` and `browser` are exposed.
 
 ### `global.jestPuppeteer.debug()`
 
@@ -92,6 +84,9 @@ it('should put test in debug mode', async () => {
 You can specify a `jest-puppeteer.config.js` at the root of the project or define a custom path using `JEST_PUPPETEER_CONFIG` environment variable.
 
 - `launch` <[object]> [All Puppeteer launch options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions) can be specified in config. Since it is JavaScript, you can use all stuff you need, including environment.
+- `browserContext` <[string]>. Defaults to `default` but can have the following values (any other will throw an error on test suite setup): 
+  - `default` Default valDefault behavior, the browser will have one instance where all tabs share the same context.
+  - `incognito` Each instance to have a separate, isolated context. Useful when running tests that could interfere with one another. (*Example: testing multiple users on the same app at once with login, transactions, etc.*)  
 - `exitOnPageError` <[boolean]> Exits page on any global error message thrown. Defaults to `true`.
 - `server` <[Object]> Server options allowed by [jest-dev-server](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-dev-server)
 

--- a/packages/jest-environment-puppeteer/README.md
+++ b/packages/jest-environment-puppeteer/README.md
@@ -60,6 +60,22 @@ it('should fill an input', async () => {
 })
 ```
 
+### `global.context`
+
+**Note: Requires puppeteer >= 1.5.0**
+
+Give access to a [Browser context](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browsercontext) that is instanciated when the browser is launched.
+
+It is possible to set the browser context inside the config `jest-puppeteer-config.js` in the root of this project. The context will always be exposed via the global `context` object the same way `page` and `browser` are exposed. 
+
+Accepted values: 
+
+* `default` Default behavior, the browser will have one instance where all tabs share the same context.
+
+* `incognito` Forces each instance to have a separate, isolated context. Useful when running tests that could interfere with one another. 
+  * Example: testing multiple users on the same app at once with login, transactions, etc.  
+
+
 ### `global.jestPuppeteer.debug()`
 
 Put test in debug mode.

--- a/packages/jest-environment-puppeteer/README.md
+++ b/packages/jest-environment-puppeteer/README.md
@@ -62,8 +62,6 @@ it('should fill an input', async () => {
 
 ### `global.context`
 
-**Note: Requires puppeteer >= 1.5.0**
-
 Give access to a [Browser context](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-browsercontext) that is instanciated when the browser is launched.
 
 It is possible to set the browser context inside the config `jest-puppeteer-config.js` in the root of this project. The context will always be exposed via the global `context` object the same way `page` and `browser` are exposed. 

--- a/packages/jest-environment-puppeteer/package.json
+++ b/packages/jest-environment-puppeteer/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "puppeteer": "^1.0.0"
+    "puppeteer": "^1.5.0"
   },
   "dependencies": {
     "chalk": "^2.4.1",

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -48,10 +48,10 @@ class PuppeteerEnvironment extends NodeEnvironment {
       browserWSEndpoint: wsEndpoint,
     })
 
-    if(config.launch.browserContext === 'incognito') {
+    if(config.browserContext === 'incognito') {
       // Using this, pages will be created in a pristine context.
       this.global.context = await this.global.browser.createIncognitoBrowserContext()
-    } else if(config.launch.browserContext === 'default') {
+    } else if(config.browserContext === 'default') {
       /**
        * Since this is a new browser, browserContexts() will return only one instance
        * https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserbrowsercontexts

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -47,11 +47,14 @@ class PuppeteerEnvironment extends NodeEnvironment {
           : undefined,
       browserWSEndpoint: wsEndpoint,
     })
-    if(config.launch.incognito) {
-      this.global.context = await this.global.browser.createIncognitoBrowserContext();
+
+    if(config.launch.browserContext === 'incognito') {
+      this.global.context = await this.global.browser.createIncognitoBrowserContext()
       // Create a new page in a pristine context.
-      this.global.page = await this.global.context.newPage();
-    } else {
+      this.global.page = await this.global.context.newPage()
+    } else if(config.launch.browserContext === 'default') {
+      // In a newly created browser, browserContexts() returns a single instance of BrowserContext.
+      this.global.context = await this.global.browser.browserContexts()[0]
       this.global.page = await this.global.browser.newPage()
     }
 

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -49,15 +49,17 @@ class PuppeteerEnvironment extends NodeEnvironment {
     })
 
     if(config.launch.browserContext === 'incognito') {
+      // Using this, pages will be created in a pristine context.
       this.global.context = await this.global.browser.createIncognitoBrowserContext()
-      // Create a new page in a pristine context.
-      this.global.page = await this.global.context.newPage()
     } else if(config.launch.browserContext === 'default') {
-      // In a newly created browser, browserContexts() returns a single instance of BrowserContext.
+      /**
+       * Since this is a new browser, browserContexts() will return only one instance
+       * https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserbrowsercontexts
+       */
       this.global.context = await this.global.browser.browserContexts()[0]
-      this.global.page = await this.global.browser.newPage()
     }
 
+    this.global.page = await this.global.context.newPage()
     if (config && config.exitOnPageError) {
       this.global.page.addListener('pageerror', handleError)
     }

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -48,15 +48,10 @@ class PuppeteerEnvironment extends NodeEnvironment {
       browserWSEndpoint: wsEndpoint,
     })
 
-    const browserContext =
-        config && config.browserContext
-            ? config.browserContext
-            : 'default'
-
-    if(browserContext === 'incognito') {
+    if(config.browserContext === 'incognito') {
       // Using this, pages will be created in a pristine context.
       this.global.context = await this.global.browser.createIncognitoBrowserContext()
-    } else if(browserContext === 'default') {
+    } else if(config.browserContext === 'default') {
       /**
        * Since this is a new browser, browserContexts() will return only one instance
        * https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserbrowsercontexts
@@ -115,15 +110,10 @@ class PuppeteerEnvironment extends NodeEnvironment {
 
   async teardown() {
     const config = await readConfig()
-    const browserContext =
-        config && config.browserContext
-            ? config.browserContext
-            : 'default'
-
     this.global.page.removeListener('pageerror', handleError)
 
-    if(browserContext === 'incognito') {
-        await this.global.context.close();
+    if(config.browserContext === 'incognito') {
+        await this.global.context.close()
     } else {
         await this.global.page.close()
     }

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -57,6 +57,8 @@ class PuppeteerEnvironment extends NodeEnvironment {
        * https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserbrowsercontexts
        */
       this.global.context = await this.global.browser.browserContexts()[0]
+    } else {
+      throw new Error(`browserContext should be either 'incognito' or 'default'. Received '${config.browserContext}'`)
     }
 
     this.global.page = await this.global.context.newPage()

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -109,8 +109,14 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    const config = await readConfig()
     this.global.page.removeListener('pageerror', handleError)
-    await this.global.page.close()
+
+    if(config.browserContext === 'incognito') {
+        await this.global.context.close();
+    } else {
+        await this.global.page.close()
+    }
   }
 }
 

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -48,10 +48,15 @@ class PuppeteerEnvironment extends NodeEnvironment {
       browserWSEndpoint: wsEndpoint,
     })
 
-    if(config.browserContext === 'incognito') {
+    const browserContext =
+        config && config.browserContext
+            ? config.browserContext
+            : 'default'
+
+    if(browserContext === 'incognito') {
       // Using this, pages will be created in a pristine context.
       this.global.context = await this.global.browser.createIncognitoBrowserContext()
-    } else if(config.browserContext === 'default') {
+    } else if(browserContext === 'default') {
       /**
        * Since this is a new browser, browserContexts() will return only one instance
        * https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#browserbrowsercontexts
@@ -110,9 +115,14 @@ class PuppeteerEnvironment extends NodeEnvironment {
 
   async teardown() {
     const config = await readConfig()
+    const browserContext =
+        config && config.browserContext
+            ? config.browserContext
+            : 'default'
+
     this.global.page.removeListener('pageerror', handleError)
 
-    if(config.browserContext === 'incognito') {
+    if(browserContext === 'incognito') {
         await this.global.context.close();
     } else {
         await this.global.page.close()

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -47,7 +47,14 @@ class PuppeteerEnvironment extends NodeEnvironment {
           : undefined,
       browserWSEndpoint: wsEndpoint,
     })
-    this.global.page = await this.global.browser.newPage()
+    if(config.launch.incognito) {
+      this.global.context = await this.global.browser.createIncognitoBrowserContext();
+      // Create a new page in a pristine context.
+      this.global.page = await this.global.context.newPage();
+    } else {
+      this.global.page = await this.global.browser.newPage()
+    }
+
     if (config && config.exitOnPageError) {
       this.global.page.addListener('pageerror', handleError)
     }

--- a/packages/jest-environment-puppeteer/src/readConfig.js
+++ b/packages/jest-environment-puppeteer/src/readConfig.js
@@ -29,8 +29,6 @@ async function readConfig() {
   const absConfigPath = path.resolve(cwd(), configPath)
   const configExists = await exists(absConfigPath)
 
-  const browserContext =
-
   if (hasCustomConfigPath && !configExists) {
     throw new Error(
       `Error: Can't find a root directory while resolving a config file path.\nProvided path to resolve: ${configPath}`,

--- a/packages/jest-environment-puppeteer/src/readConfig.js
+++ b/packages/jest-environment-puppeteer/src/readConfig.js
@@ -8,12 +8,14 @@ const exists = promisify(fs.exists)
 
 const DEFAULT_CONFIG = {
   launch: {},
+  browserContext: 'default',
   exitOnPageError: true,
 }
 const DEFAULT_CONFIG_CI = {
   launch: {
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
   },
+  browserContext: 'default',
   exitOnPageError: true,
 }
 
@@ -26,6 +28,8 @@ async function readConfig() {
     process.env.JEST_PUPPETEER_CONFIG || 'jest-puppeteer.config.js'
   const absConfigPath = path.resolve(cwd(), configPath)
   const configExists = await exists(absConfigPath)
+
+  const browserContext =
 
   if (hasCustomConfigPath && !configExists) {
     throw new Error(

--- a/packages/jest-environment-puppeteer/tests/.eslintrc.js
+++ b/packages/jest-environment-puppeteer/tests/.eslintrc.js
@@ -6,5 +6,6 @@ module.exports = {
   globals: {
     page: true,
     browser: true,
+    context:true,
   },
 }

--- a/packages/jest-puppeteer-preset/package.json
+++ b/packages/jest-puppeteer-preset/package.json
@@ -14,7 +14,7 @@
     "chrome-headless"
   ],
   "peerDependencies": {
-    "puppeteer": "^1.0.0"
+    "puppeteer": "^1.5.0"
   },
   "dependencies": {
     "expect-puppeteer": "^3.2.0",

--- a/packages/jest-puppeteer/package.json
+++ b/packages/jest-puppeteer/package.json
@@ -13,7 +13,7 @@
     "chrome-headless"
   ],
   "peerDependencies": {
-    "puppeteer": "^1.0.0"
+    "puppeteer": "^1.5.0"
   },
   "dependencies": {
     "expect-puppeteer": "^3.2.0",


### PR DESCRIPTION
Related issue : https://github.com/smooth-code/jest-puppeteer/issues/81

- Add config parameter to set incognito mode (default: false)
- In environment setup, read from config and launch the page in incognito mode

Note: In headful mode, this seems to launch a separate chrome instance per tab as discussed here (apparently there's no performance overhead) : https://github.com/GoogleChrome/puppeteer/issues/85#issuecomment-392251197

I checked for unit tests if I needed to add any, it doesn't seem like it but please let me know if anything is wrong, I'll be happy to fix it !