### PR TITLE
Use PID based wsEndpoint file

### DIFF
--- a/packages/jest-environment-puppeteer/src/constants.js
+++ b/packages/jest-environment-puppeteer/src/constants.js
@@ -2,4 +2,4 @@ import path from 'path'
 import os from 'os'
 
 export const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
-export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint')
+export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint-' + process.pid)

--- a/packages/jest-environment-puppeteer/src/constants.js
+++ b/packages/jest-environment-puppeteer/src/constants.js
@@ -2,4 +2,4 @@ import path from 'path'
 import os from 'os'
 
 export const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
-export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint-' + process.pid)
+export const WS_ENDPOINT_PATH = path.join(DIR, `wsEndpoint-${process.pid}`)


### PR DESCRIPTION
Allows multiple Jest processes to connect to their own chromium instances