### PR TITLE
Proper WS-Endpoint via pid management

### DIFF
--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -32,7 +32,16 @@ class PuppeteerEnvironment extends NodeEnvironment {
     const config = await readConfig()
     this.global.puppeteerConfig = config
 
-    const wsEndpoint = fs.readFileSync(WS_ENDPOINT_PATH, 'utf8')
+    let wsEndpoint;
+    try {
+        wsEndpoint = _fs2.default.readFileSync(_constants.WS_ENDPOINT_PATH + process.pid, 'utf8');
+    } catch (e) {
+        try {
+            wsEndpoint = _fs2.default.readFileSync(_constants.WS_ENDPOINT_PATH + process.ppid, 'utf8');
+        } catch (e) {
+            console.log(e, process.ppid, "process.ppid requires node v9.2.0");
+        }
+    }
     if (!wsEndpoint) {
       throw new Error('wsEndpoint not found')
     }

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -34,7 +34,7 @@ class PuppeteerEnvironment extends NodeEnvironment {
 
     let wsEndpoint;
     try {
-        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + (process.ppid) ? process.pid : "", 'utf8')
+        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + ((process.ppid) ? process.pid : ""), 'utf8')
     } catch (e) {
         wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + process.ppid, 'utf8')
     }

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -34,13 +34,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
 
     let wsEndpoint;
     try {
-        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + process.pid, 'utf8')
+        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + (process.ppid) ? process.pid : "", 'utf8')
     } catch (e) {
-        try {
-            wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + process.ppid, 'utf8')
-        } catch (e) {
-            throw new Error(`process.ppid requires node v9.2.0${'\n'}${process.ppid}${'\n'}e`)
-        }
+        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + process.ppid, 'utf8')
     }
     if (!wsEndpoint) {
       throw new Error('wsEndpoint not found')

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -34,9 +34,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
 
     let wsEndpoint;
     try {
-        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + ((process.ppid) ? process.pid : ""), 'utf8')
+        wsEndpoint = fs.readFileSync(WS_ENDPOINT_PATH + ((process.ppid) ? process.pid : ""), 'utf8')
     } catch (e) {
-        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + process.ppid, 'utf8')
+        wsEndpoint = fs.readFileSync(WS_ENDPOINT_PATH + process.ppid, 'utf8')
     }
     if (!wsEndpoint) {
       throw new Error('wsEndpoint not found')

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -34,12 +34,12 @@ class PuppeteerEnvironment extends NodeEnvironment {
 
     let wsEndpoint;
     try {
-        wsEndpoint = _fs2.default.readFileSync(_constants.WS_ENDPOINT_PATH + process.pid, 'utf8');
+        wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + process.pid, 'utf8')
     } catch (e) {
         try {
-            wsEndpoint = _fs2.default.readFileSync(_constants.WS_ENDPOINT_PATH + process.ppid, 'utf8');
+            wsEndpoint = fs.default.readFileSync(WS_ENDPOINT_PATH + process.ppid, 'utf8')
         } catch (e) {
-            console.log(e, process.ppid, "process.ppid requires node v9.2.0");
+            throw new Error(`process.ppid requires node v9.2.0${'\n'}${process.ppid}${'\n'}e`)
         }
     }
     if (!wsEndpoint) {

--- a/packages/jest-environment-puppeteer/src/constants.js
+++ b/packages/jest-environment-puppeteer/src/constants.js
@@ -2,4 +2,4 @@ import path from 'path'
 import os from 'os'
 
 export const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
-export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint')
+export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint-' + process.pid)

--- a/packages/jest-environment-puppeteer/src/constants.js
+++ b/packages/jest-environment-puppeteer/src/constants.js
@@ -2,4 +2,4 @@ import path from 'path'
 import os from 'os'
 
 export const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
-export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint-' + process.pid)
+export const WS_ENDPOINT_PATH = path.join(DIR, `wsEndpoint-${process.pid}`)

--- a/packages/jest-environment-puppeteer/src/constants.js
+++ b/packages/jest-environment-puppeteer/src/constants.js
@@ -2,4 +2,4 @@ import path from 'path'
 import os from 'os'
 
 export const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
-export const WS_ENDPOINT_PATH = path.join(DIR, `wsEndpoint-${process.pid}`)
+export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint')

--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -19,7 +19,7 @@ export async function setup() {
   const config = await readConfig()
   browser = await puppeteer.launch(config.launch)
   mkdirp.sync(DIR)
-  fs.writeFileSync(WS_ENDPOINT_PATH, browser.wsEndpoint())
+  fs.writeFileSync(WS_ENDPOINT_PATH + process.pid, browser.wsEndpoint())
 
   if (config.server) {
     try {

--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -19,7 +19,7 @@ export async function setup() {
   const config = await readConfig()
   browser = await puppeteer.launch(config.launch)
   mkdirp.sync(DIR)
-  fs.writeFileSync(WS_ENDPOINT_PATH + process.pid, browser.wsEndpoint())
+  fs.writeFileSync(WS_ENDPOINT_PATH + (process.ppid) ? process.pid : "", browser.wsEndpoint())
 
   if (config.server) {
     try {

--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -19,7 +19,7 @@ export async function setup() {
   const config = await readConfig()
   browser = await puppeteer.launch(config.launch)
   mkdirp.sync(DIR)
-  fs.writeFileSync(WS_ENDPOINT_PATH + (process.ppid) ? process.pid : "", browser.wsEndpoint())
+  fs.writeFileSync(WS_ENDPOINT_PATH + ((process.ppid) ? process.pid : ""), browser.wsEndpoint())
 
   if (config.server) {
     try {


### PR DESCRIPTION
Requires support for process.ppid which is in node v 9.2.0
Global will always assign ws-endpoint via its pid, PuppeteerEnvironment will try to find the ws-endpoint via its pid first (valid in the case of a single test file), and will use its ppid instead of that fails.
PPID of child process PupeteerEnvironment should match PID of parent process Global.
