### PR TITLE
Fix for Race Condition on setting WSendpoint (#98)

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,10 +1,15 @@
+const TEST_SERVER_PORT = process.env.TEST_SERVER_PORT
+  ? parseInt(process.env.TEST_SERVER_PORT, 10) : 4444
+
+process.env.TEST_SERVER_PORT = TEST_SERVER_PORT
+
 module.exports = {
   launch: {
     headless: process.env.CI === 'true',
   },
   server: {
-    command: 'node server',
-    port: 4444,
+    command: `node server ${TEST_SERVER_PORT}`,
+    port: TEST_SERVER_PORT,
     launchTimeout: 4000,
   },
 }

--- a/packages/expect-puppeteer/src/index.test.js
+++ b/packages/expect-puppeteer/src/index.test.js
@@ -2,7 +2,7 @@ const { getDefaultOptions, setDefaultOptions } = require('.')
 
 describe('expect-puppeteer', () => {
   beforeEach(async () => {
-    await page.goto('http://localhost:4444')
+    await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
   it('should work with original Jest matchers', async () => {

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -1,10 +1,8 @@
-import fs from 'fs'
 // eslint-disable-next-line
 import NodeEnvironment from 'jest-environment-node'
 import puppeteer from 'puppeteer'
 import chalk from 'chalk'
 import readConfig from './readConfig'
-import { WS_ENDPOINT_PATH } from './constants'
 
 const handleError = error => {
   process.emit('uncaughtException', error)
@@ -32,7 +30,7 @@ class PuppeteerEnvironment extends NodeEnvironment {
     const config = await readConfig()
     this.global.puppeteerConfig = config
 
-    const wsEndpoint = fs.readFileSync(WS_ENDPOINT_PATH, 'utf8')
+    const wsEndpoint = process.env.PUPPETEER_WS_ENDPOINT
     if (!wsEndpoint) {
       throw new Error('wsEndpoint not found')
     }

--- a/packages/jest-environment-puppeteer/src/constants.js
+++ b/packages/jest-environment-puppeteer/src/constants.js
@@ -1,5 +1,0 @@
-import path from 'path'
-import os from 'os'
-
-export const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
-export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint')

--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -1,25 +1,20 @@
 /* eslint-disable no-console */
-import fs from 'fs'
 import {
   setup as setupServer,
   teardown as teardownServer,
   ERROR_TIMEOUT,
   ERROR_NO_COMMAND,
 } from 'jest-dev-server'
-import mkdirp from 'mkdirp'
-import rimraf from 'rimraf'
 import puppeteer from 'puppeteer'
 import chalk from 'chalk'
 import readConfig from './readConfig'
-import { DIR, WS_ENDPOINT_PATH } from './constants'
 
 let browser
 
 export async function setup() {
   const config = await readConfig()
   browser = await puppeteer.launch(config.launch)
-  mkdirp.sync(DIR)
-  fs.writeFileSync(WS_ENDPOINT_PATH, browser.wsEndpoint())
+  process.env.PUPPETEER_WS_ENDPOINT = browser.wsEndpoint()
 
   if (config.server) {
     try {
@@ -53,5 +48,4 @@ export async function setup() {
 export async function teardown() {
   await teardownServer()
   await browser.close()
-  rimraf.sync(DIR)
 }

--- a/server/index.js
+++ b/server/index.js
@@ -5,4 +5,4 @@ const app = express()
 
 app.use(express.static(path.join(__dirname, 'public')))
 
-app.listen(4444)
+app.listen(process.argv[2])


### PR DESCRIPTION
An alternative to the approach in #103, instead using environment variables.

### Demo:
```yarn test & TEST_SERVER_PORT=4445 yarn test```