### PR TITLE
Disable tab throttling

### DIFF
--- a/packages/jest-environment-puppeteer/src/readConfig.js
+++ b/packages/jest-environment-puppeteer/src/readConfig.js
@@ -11,13 +11,17 @@ const DEFAULT_CONFIG = {
   browserContext: 'default',
   exitOnPageError: true,
 }
-const DEFAULT_CONFIG_CI = {
+const DEFAULT_CONFIG_CI = merge(DEFAULT_CONFIG, {
   launch: {
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  },
-  browserContext: 'default',
-  exitOnPageError: true,
-}
+    args: [
+      '--no-sandbox', 
+      '--disable-setuid-sandbox',
+      '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding'
+    ],
+  }
+})
 
 async function readConfig() {
   const defaultConfig =

--- a/packages/jest-environment-puppeteer/tests/readConfig.test.js
+++ b/packages/jest-environment-puppeteer/tests/readConfig.test.js
@@ -54,5 +54,18 @@ describe('readConfig', () => {
       const config = await readConfig()
       expect(config.server).not.toBeDefined()
     })
+
+    it('should return default config with launch args', async () => {
+      mockExists(false)
+      process.env.CI = true
+      const config = await readConfig()
+      expect(config.launch.args).toEqual([
+        '--no-sandbox', 
+        '--disable-setuid-sandbox',
+        '--disable-background-timer-throttling',
+        '--disable-backgrounding-occluded-windows',
+        '--disable-renderer-backgrounding'
+      ])
+    })
   })
 })


### PR DESCRIPTION
## Summary
This flags were added to default config:
```js
'--disable-background-timer-throttling'
'--disable-backgrounding-occluded-windows'
'--disable-renderer-backgrounding'
```

## Test plan
I created a test to make sure that everything is okay with `launch.args`.

fixes https://github.com/smooth-code/jest-puppeteer/issues/137