### PR TITLE
fix: skip closing external browser on teardown

### DIFF
--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -50,9 +50,12 @@ export async function setup() {
 }
 
 export async function teardown() {
-  const config = await readConfig()
   await teardownServer()
-  if (!config.connect) {
+  
+  const config = await readConfig()
+  if (config.connect) {
+    await browser.disconnect();
+  } else {
     await browser.close()
   }
 }

--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -50,6 +50,9 @@ export async function setup() {
 }
 
 export async function teardown() {
+  const config = await readConfig()
   await teardownServer()
-  await browser.close()
+  if (!config.connect) {
+    await browser.close()
+  }
 }


### PR DESCRIPTION
Use `.disconnect` method in teardown phase, as a complement to the `.connect` method in the setup phase.

## Summary

This allows long-running external instances of chromium to be managed independently of the jest test runner, and/or possible reuse of the chromium instances across different test runs and projects.

For example, our use case it to run multiple chromium instances (similar to selenium's grid) and allow different projects to `connect` and run their test suites against the grid. 

See pptr docs:
https://pptr.dev/#?product=Puppeteer&version=v1.11.0&show=api-browserdisconnect

## Test plan

Running an external browser, which jest-puppeteer can connect to and at the end of the test suite, the browser remains open.

