### PR TITLE
Disconnect the browser on environment teardown

### DIFF
--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -114,6 +114,8 @@ class PuppeteerEnvironment extends NodeEnvironment {
     } else {
       await this.global.page.close()
     }
+
+    await this.global.browser.disconnect()
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Environment setup and teardown should be symmetric. Since we connect to the browser on setup, we should disconnect on teardown. I'm not sure if it has actual implications but it seems like the right thing to do.

## Test plan

There are no explicit tests for that area, although existing tests should continue to pass. They will fail if this new code is broken (verified).