### PR TITLE
Make tests run on Windows

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   browserContext: process.env.INCOGNITO ? 'incognito' : 'default',
   server: {
-    command: `PORT=${port} node server`,
+    command: `cross-env PORT=${port} node server`,
     port,
     launchTimeout: 4000,
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "release": "lerna publish --conventional-commits && conventional-github-releaser --preset angular",
     "test": "jest --runInBand",
-    "test:incognito": "INCOGNITO=true jest --runInBand"
+    "test:incognito": "cross-env INCOGNITO=true jest --runInBand"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",
@@ -21,6 +21,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "conventional-github-releaser": "^3.1.2",
+    "cross-env": "^5.2.0",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,6 +2623,14 @@ cosmiconfig@^5.0.2:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -4660,7 +4668,7 @@ is-windows@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
   integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
On Windows ENV variables are set differently from *NIX systems. Use cross-env to set ENV vars correctly for all OSes.

## Summary

Tests did not run on Windows systems before, making it hard for Windows users to contribute. This PR makes tests run on Windows without inconveniencing users of other OSes.

## Test plan

Tests can still be run with `yarn test`.