### PR TITLE
fix: Jest --watch fails to reload

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -12,6 +12,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "test:integration": "jest -c integration/jest.config.js",
+    "test:integrationWithWatch": "jest -c integration/jest.config.js --watch",
     "eject": "react-scripts eject"
   },
   "devDependencies": {

--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -11,7 +11,7 @@ import readConfig from './readConfig'
 
 let browser
 
-export async function setup() {
+export async function setup(jestConfig) {
   const config = await readConfig()
   if (config.connect) {
     browser = await puppeteer.connect(config.connect)
@@ -19,6 +19,8 @@ export async function setup() {
     browser = await puppeteer.launch(config.launch)
   }
   process.env.PUPPETEER_WS_ENDPOINT = browser.wsEndpoint()
+
+  if (jestConfig.watch || jestConfig.watchAll) return
 
   if (config.server) {
     try {
@@ -49,13 +51,15 @@ export async function setup() {
   }
 }
 
-export async function teardown() {
-  await teardownServer()
-  
-  const config = await readConfig()
-  if (config.connect) {
-    await browser.disconnect();
-  } else {
-    await browser.close()
+export async function teardown(jestConfig) {
+  if (!jestConfig.watch && !jestConfig.watchAll) {
+    await teardownServer()
+
+    const config = await readConfig()
+    if (config.connect) {
+      await browser.disconnect()
+    } else {
+      await browser.close()
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

close https://github.com/smooth-code/jest-puppeteer/issues/181

## Test plan

- ```npm run test:integrationWithWatch``` is running normally in cra example
