### PR TITLE
fix: wrong timeout when using jestPuppeteer.debug()

### DIFF
--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -66,7 +66,7 @@ class PuppeteerEnvironment extends NodeEnvironment {
       debug: async () => {
         // eslint-disable-next-line no-eval
         // Set timeout to 4 days
-        this.setTimeout(345600)
+        this.setTimeout(345600000)
         // Run a debugger (in case Puppeteer has been launched with `{ devtools: true }`)
         await this.global.page.evaluate(() => {
           // eslint-disable-next-line no-debugger


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

see https://github.com/smooth-code/jest-puppeteer/issues/184
