### PR TITLE
Adjust example on README.md to pass globalConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ For this use case, `jest-environment-puppeteer` exposes two methods: `setup` and
 // global-setup.js
 const { setup: setupPuppeteer } = require('jest-environment-puppeteer')
 
-module.exports = async function globalSetup() {
-  await setupPuppeteer()
+module.exports = async function globalSetup(globalConfig) {
+  await setupPuppeteer(globalConfig)
   // Your global setup
 }
 ```
@@ -242,9 +242,9 @@ module.exports = async function globalSetup() {
 // global-teardown.js
 const { teardown: teardownPuppeteer } = require('jest-environment-puppeteer')
 
-module.exports = async function globalTeardown() {
+module.exports = async function globalTeardown(globalConfig) {
   // Your global teardown
-  await teardownPuppeteer()
+  await teardownPuppeteer(globalConfig)
 }
 ```
 


### PR DESCRIPTION
## Summary

Hey, pretty simple: Since https://github.com/smooth-code/jest-puppeteer/commit/cc9bbfa493349cc88273120996e713523cf86714 `jest-puppeteer`'s `globalSetup` needs `jest`'s `globalConfig`. If a user creates their own config they should pass `jest`'s `globalConfig`.
