### PR TITLE
Update readme

### DIFF
--- a/packages/expect-puppeteer/README.md
+++ b/packages/expect-puppeteer/README.md
@@ -31,7 +31,7 @@ To use with Jest, just modify your configuration:
 
 ```json
 {
-  "setupTestFrameworkScriptFile": "expect-puppeteer"
+  "setupFilesAfterEnv": ["expect-puppeteer"]
 }
 ```
 


### PR DESCRIPTION
## Summary

Just a quick update to docs after receiving the following message:

>   Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.
https://jestjs.io/docs/configuration.html

## Test plan

Change to the new API and run `jest`. Should work as expected.
