### PR TITLE
Warn new users that they need to remove `testEnvironment` from Jest configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Update your Jest configuration:
   "preset": "jest-puppeteer"
 }
 ```
+**NOTE**: Be sure to remove any existing `testEnvironment` option from your Jest configuration. The `jest-puppeteer` preset needs to manage that option itself.
 
 Use Puppeteer in your tests:
 


### PR DESCRIPTION
## Summary

Resolves #162.

I just got confused by this issue too, which made for a somewhat rocky first impression of the tool. Maybe this additional warning would help?

## Test plan

None, it's docs :)

