### PR TITLE
fix: Cannot read property watch of undefined in jest v22 version

### DIFF
--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -11,7 +11,7 @@ import readConfig from './readConfig'
 
 let browser
 
-export async function setup(jestConfig) {
+export async function setup(jestConfig = {}) {
   const config = await readConfig()
   if (config.connect) {
     browser = await puppeteer.connect(config.connect)
@@ -51,7 +51,7 @@ export async function setup(jestConfig) {
   }
 }
 
-export async function teardown(jestConfig) {
+export async function teardown(jestConfig = {}) {
   if (!jestConfig.watch && !jestConfig.watchAll) {
     await teardownServer()
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

close https://github.com/smooth-code/jest-puppeteer/issues/195

## Test plan

- [x] Jest-puppeteer works fine in jest v22 version
- [x] Jest-puppeteer works fine in jest v23 version