### PR TITLE
docs: clarify setup file customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,22 +172,25 @@ module.exports = {
 }
 ```
 
-### Specify a `setupTestFrameworkScriptFile`
+### Custom `setupTestFrameworkScriptFile` or `setupFilesAfterEnv`
 
-Jest Puppeteer use `expect-puppeteer` as `setupTestFrameworkScriptFile`. If you want to use `expect-puppeteer` don't forget to add it in your custom `setupTestFrameworkScriptFile`:
+If you use custom setup files, you'll need to include `expect-puppeteer` yourself in order to use the matchers it provides. Add the following to your setup file.
 
 ```js
-// setupTestFrameworkScriptFile.js
+// setup.js
 require('expect-puppeteer')
 
 // Your custom setup
+// ...
 ```
 
 ```js
 // jest.config.js
 module.exports = {
   // ...
-  setupTestFrameworkScriptFile: './setupTestFrameworkScriptFile.js',
+  setupTestFrameworkScriptFile: './setup.js',
+  // or
+  setupFilesAfterEnv: [ './setup.js' ]
 }
 ```
 


### PR DESCRIPTION
## Summary

This clarifies the documentation around custom setup files. First, you only need to do it if you're customizing one of the two setup properties. Secondly, `setupTestFrameworkScriptFile` is now deprecated in favor `setupFilesAfterEnv` so I figured it was good to add that to the docs:

https://jestjs.io/docs/en/configuration#setupfilesafterenv-array

## Test plan

N/A as this is a documentation change?