### PR TITLE
feat: Add visible options to toMatchElement config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 lib/
+yarn-error.log

--- a/packages/expect-puppeteer/README.md
+++ b/packages/expect-puppeteer/README.md
@@ -165,6 +165,7 @@ Expect an element be present in the page or element.
     - `mutation` - to execute `pageFunction` on every DOM mutation.
   - `timeout` <[number]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout) method.
   - `text` <[string]|[RegExp]> A text or a RegExp to match in element `textContent`.
+  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 
 ```js
 // Select a row containing a text

--- a/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
+++ b/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
@@ -37,6 +37,42 @@ describe('toMatchElement', () => {
         expect(error.message).toMatch('waiting for function failed')
       }
     })
+
+    it('should match using visible options', async () => {
+      expect.assertions(11)
+
+      const normalElement = await expect(page).toMatchElement('.normal', {
+        visible: true,
+      })
+      const textContentProperty = await normalElement.getProperty('textContent')
+      const textContent = await textContentProperty.jsonValue()
+      expect(textContent).toBe('normal element')
+
+      try {
+        await expect(page).toMatchElement('.hidden', { visible: true })
+      } catch (error) {
+        expect(error.message).toMatch('Element .hidden not found')
+        expect(error.message).toMatch('waiting for function failed')
+      }
+
+      try {
+        await expect(page).toMatchElement('.displayed', { visible: true })
+      } catch (error) {
+        expect(error.message).toMatch('Element .displayed not found')
+        expect(error.message).toMatch('waiting for function failed')
+      }
+
+      try {
+        await expect(page).toMatchElement('.displayedWithClassname', {
+          visible: true,
+        })
+      } catch (error) {
+        expect(error.message).toMatch(
+          'Element .displayedWithClassname not found',
+        )
+        expect(error.message).toMatch('waiting for function failed')
+      }
+    })
   })
 
   describe('ElementHandle', () => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -5,6 +5,11 @@
   <meta charset="utf-8">
   <title>Test App</title>
 </head>
+<style>
+  .displayedWithClassname {
+    display: none;
+  }
+</style>
 
 <body>
   <header>This is home!</header>
@@ -25,6 +30,10 @@
     <div id="in-the-main">
       A div in the main
     </div>
+    <div style="visibility: hidden;" class="hidden">hidden element</div>
+    <div style="display: none" class="displayed">displayed element</div>
+    <div class="displayedWithClassname">displayed element</div>
+    <div class="normal">normal element</div>
   </main>
 </body>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Add visible options to toMatchElement config,.
wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.


see https://github.com/smooth-code/jest-puppeteer/issues/207

## Test plan

see test case