### PR TITLE
fix invalid connect options, when using browserURL

### DIFF
--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -37,6 +37,7 @@ class PuppeteerEnvironment extends NodeEnvironment {
     this.global.browser = await puppeteer.connect({
       ...config.connect,
       ...config.launch,
+      browserURL: undefined,
       browserWSEndpoint: wsEndpoint,
     })
 

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -125,10 +125,8 @@ class PuppeteerEnvironment extends NodeEnvironment {
       if (context) {
         await context.close()
       }
-    } else {
-      if (page) {
-        await page.close()
-      }
+    } else if (page) {
+      await page.close()
     }
 
     if (browser) {

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -115,16 +115,25 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
-    const config = await readConfig()
-    this.global.page.removeListener('pageerror', handleError)
+    const { page, context, browser, puppeteerConfig } = this.global
 
-    if (config.browserContext === 'incognito') {
-      await this.global.context.close()
-    } else {
-      await this.global.page.close()
+    if (page) {
+      page.removeListener('pageerror', handleError)
     }
 
-    await this.global.browser.disconnect()
+    if (puppeteerConfig.browserContext === 'incognito') {
+      if (context) {
+        await context.close()
+      }
+    } else {
+      if (page) {
+        await page.close()
+      }
+    }
+
+    if (browser) {
+      await browser.disconnect()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Specifying both options `browserURL` and `browserWSEndpoint` is invalid when calling connect. Since `PuppeteerEnvironment` always gets a WS endpoint prepared from global setup, we must unset the `browserURL` option.

Edit: Since this problem also exists in v3, it would be nice to backport this, since v4 does not support jest v23 anymore

Edit2: This most likely fixes #200, at least my occurence of it. The real problem is that setup exceptions get swallowed, if teardown also throws. Guessing that the jest code looks something like this:
```js
try {
  env.setup();
  test();
} catch(e) {
  env.teardown();
  throw e;
}
```
So the actual problem (setup failing) gets shadowed by the teardown fragility not being able to do its work on a dirty env.