### PR TITLE
chore(jest-dev-server): reduce number of deps by replacing inquirer with prompts

### DIFF
--- a/packages/jest-dev-server/package.json
+++ b/packages/jest-dev-server/package.json
@@ -21,7 +21,7 @@
     "chalk": "^2.4.2",
     "cwd": "^0.10.0",
     "find-process": "^1.2.1",
-    "inquirer": "^6.2.2",
+    "prompts": "^2.0.4",
     "spawnd": "^4.0.0",
     "tree-kill": "^1.2.1",
     "wait-port": "^0.2.2"

--- a/packages/jest-dev-server/src/global.js
+++ b/packages/jest-dev-server/src/global.js
@@ -138,14 +138,16 @@ async function setupJestServer(providedConfig, index) {
     },
     async ask() {
       console.log('')
-      const answers = await prompts({
-        type: 'confirm',
-        name: 'kill',
-        message: `Another process is listening on ${
-          config.port
-        }. Should I kill it for you? On linux, this may require you to enter your password.`,
-        initial: true,
-      })
+      const answers = await outOfStin(() =>
+        prompts({
+          type: 'confirm',
+          name: 'kill',
+          message: `Another process is listening on ${
+            config.port
+          }. Should I kill it for you? On linux, this may require you to enter your password.`,
+          initial: true,
+        }),
+      )
       if (answers.kill) {
         const [portProcess] = await findProcess('port', config.port)
         logProcDetection(portProcess, config.port)

--- a/packages/jest-dev-server/src/global.js
+++ b/packages/jest-dev-server/src/global.js
@@ -8,7 +8,7 @@ import waitPort from 'wait-port'
 import findProcess from 'find-process'
 import { promisify } from 'util'
 import treeKill from 'tree-kill'
-import inquirer from 'inquirer'
+import prompts from 'prompts'
 
 const DEFAULT_CONFIG = {
   debug: false,
@@ -138,18 +138,14 @@ async function setupJestServer(providedConfig, index) {
     },
     async ask() {
       console.log('')
-      const answers = await outOfStin(() =>
-        inquirer.prompt([
-          {
-            type: 'confirm',
-            name: 'kill',
-            message: `Another process is listening on ${
-              config.port
-            }. Should I kill it for you? On linux, this may require you to enter your password.`,
-            default: true,
-          },
-        ]),
-      )
+      const answers = await prompts({
+        type: 'confirm',
+        name: 'kill',
+        message: `Another process is listening on ${
+          config.port
+        }. Should I kill it for you? On linux, this may require you to enter your password.`,
+        initial: true,
+      })
       if (answers.kill) {
         const [portProcess] = await findProcess('port', config.port)
         logProcDetection(portProcess, config.port)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,11 +1534,6 @@ ansi-escapes@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
   integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
 
-ansi-escapes@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
-  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -3429,7 +3424,7 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^3.0.0, external-editor@^3.0.3:
+external-editor@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
   integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
@@ -4373,25 +4368,6 @@ inquirer@^6.1.0, inquirer@^6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
-  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
-  dependencies:
-    ansi-escapes "^3.2.0"
-    chalk "^2.4.2"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^2.0.0"
-    lodash "^4.17.11"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rxjs "^6.4.0"
-    string-width "^2.1.0"
-    strip-ansi "^5.0.0"
-    through "^2.3.6"
-
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -5328,6 +5304,11 @@ kleur@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.1.tgz#4f5b313f5fa315432a400f19a24db78d451ede62"
   integrity sha512-P3kRv+B+Ra070ng2VKQqW4qW7gd/v3iD8sy/zOdcYRsfiD+QBokQNOps/AfP6Hr48cBhIIBFWckB9aO+IZhrWg==
+
+kleur@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.2.tgz#83c7ec858a41098b613d5998a7b653962b504f68"
+  integrity sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==
 
 lazy-cache@^0.2.3:
   version "0.2.7"
@@ -6873,6 +6854,14 @@ prompts@^2.0.1:
     kleur "^3.0.0"
     sisteransi "^1.0.0"
 
+prompts@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.0.4.tgz#179f9d4db3128b9933aa35f93a800d8fce76a682"
+  integrity sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==
+  dependencies:
+    kleur "^3.0.2"
+    sisteransi "^1.0.0"
+
 promzard@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
@@ -7443,13 +7432,6 @@ rxjs@^6.3.3:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
   integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
-  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Reduce the number of jest-dev-server dependencies by half by replacing `inquirer` package with `prompts` .

## Summary

jest-dev-server currently uses [inquirer](https://www.npmjs.com/package/inquirer) to display prompt when `usedPortAction='ask'`. This package has 26 dependencies (see: http://npm.broofa.com/?q=inquirer@6.2.2) which account for about half (!) of all dependencies of jest-dev-server (see: http://npm.broofa.com/?q=jest-dev-server@4.0.0). This seems a lot for such a minor feature.

By replacing inquirer with [prompts](https://www.npmjs.com/package/prompts), we can drastically reduce this number. Prompts is well established project, with over 10M downloads per months and 300 direct dependents. By looking at the number of open issues and PR,  it also seems to be better maintained that inquirer.

## Test plan

There is no functional impact of this change:

![screenshot](https://gist.github.com/lukaszfiszer/129f2b8b13cc2d3ffa83d9fdc41da1a8/raw/d8b76a0b7f9b92951289d0fca8085573e047a4d4/promts.png)

![screenshot](https://gist.github.com/lukaszfiszer/129f2b8b13cc2d3ffa83d9fdc41da1a8/raw/7d0a52acf8ca4ea40e1b9cc29e973a379e399b2c/promts2.png)

