### PR TITLE
Do not attempt to start the server when `usedPortAction` is `ignore` and `isPortTaken` is `true`

### DIFF
--- a/packages/jest-dev-server/src/global.js
+++ b/packages/jest-dev-server/src/global.js
@@ -174,9 +174,16 @@ async function setupJestServer(providedConfig, index) {
     if (isPortTaken) {
       await usedPortHandler()
     }
-  }
 
-  runServer(config, index)
+    if (config.usedPortAction === 'ignore' && isPortTaken) {
+      console.log('')
+      console.log('Port is already taken. Assuming server is already running.')
+    } else {
+      runServer(config, index)
+    }
+  } else {
+    runServer(config, index)
+  }
 
   if (config.port) {
     const { launchTimeout } = config


### PR DESCRIPTION
## Summary

I have a dev server already running and used `usedPortAction: 'ignore'` but the server is still attempted to be started despite the port showing as being taken. This patch puts a fork in the code to _not_ attempt to start the server if `ignore` is used and `isPortTaken` is `true`.

## Test plan

Start a server on a given port. Then attempt to use the same port in jest-dev-server config using `usedPortAction: 'ignore'`. Without the patch, the code will throw an `EADDRINUSE` error. This is because it will still attempt to run the given command. With the patch, it will simply run the tests.

## Workaround

For now, I'm just trapping the `EADDRINUSE` error for my `command` (in this specific case it is an express.js server):

```
  command: `node -e "server = require('./server');server.listen(${config.get('ports.server')}).on('error', (err) => { if (err.code !== 'EADDRINUSE') throw new Error(err) })"
```