### PR TITLE
feat: use host in port check

### DIFF
--- a/packages/jest-dev-server/src/global.js
+++ b/packages/jest-dev-server/src/global.js
@@ -88,7 +88,7 @@ async function outOfStin(block) {
   return result
 }
 
-function getIsPortTaken(port) {
+function getIsPortTaken(config) {
   let server
   const cleanupAndReturn = result =>
     new Promise(resolve => server.once('close', () => resolve(result)).close())
@@ -99,7 +99,7 @@ function getIsPortTaken(port) {
         err.code === 'EADDRINUSE' ? resolve(cleanupAndReturn(true)) : reject(),
       )
       .once('listening', () => resolve(cleanupAndReturn(false)))
-      .listen(port)
+      .listen(config.port, config.host)
   })
 }
 
@@ -170,7 +170,7 @@ async function setupJestServer(providedConfig, index) {
   }
 
   if (config.port) {
-    const isPortTaken = await getIsPortTaken(config.port)
+    const isPortTaken = await getIsPortTaken(config)
     if (isPortTaken) {
       await usedPortHandler()
     }

--- a/packages/jest-dev-server/src/global.js
+++ b/packages/jest-dev-server/src/global.js
@@ -134,7 +134,7 @@ async function setupJestServer(providedConfig, index) {
       )
       const [portProcess] = await findProcess('port', config.port)
       logProcDetection(portProcess, config.port)
-      killProc(portProcess)
+      await killProc(portProcess)
     },
     async ask() {
       console.log('')


### PR DESCRIPTION
## Summary
Problem 1: 
When setting up a dev server a host value can be provided. However, the check to see if a port is already in use does not consider this host value. This leads to ports that are in use falsely being reported as free and then a `EARINUSE` failure.

Problem 2: 
`userPortAction: 'kill'` also results in a `EARINUSE` failure. This is due to the server being started before waiting for the existing process to be killed. 

## Test plan
- Start a server on a specific host and port. 
- Provide the host and port in the jest-dev-server config and set `usedPortAction: 'kill'`, e.g.
`module.exports = {
  server: {
    usedPortAction: 'kill',
    command: 'npm start',
    host: 'test.host',
    port: 8989
  }
};`
- Run the tests

**Expected Behaviour**
Running the tests should: 
1. kill the conflicting process
2. start a new dev server
3. run the tests. 

