### PR TITLE
fix: jest-dev-server can't detect used ports

### DIFF
--- a/packages/jest-dev-server/README.md
+++ b/packages/jest-dev-server/README.md
@@ -143,9 +143,9 @@ module.exports = {
 
 ### `protocol`
 
-Type: `string`, default to `null`.
+Type: `string`, (`https`, `http`, `tcp`, `socket`) default to `tcp`.
 
-To wait for an HTTP endpoint before considering the server running, include `http` as a protocol.
+To wait for an HTTP or TCP endpoint before considering the server running, include `http` or `tcp` as a protocol.
 Must be used in conjunction with `port`.
 
 ```js


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

see https://github.com/smooth-code/jest-puppeteer/issues/233

## Test plan

this [repo](https://github.com/Dilatorily/jest-puppeteer-issue) can run normally
