### PR TITLE
resetBrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ beforeEach(async () => {
 
 ### `global.jestPuppeteer.resetBrowser()`
 
-Reset global.browser, gllobal.context, and global.page
+Reset global.browser, global.context, and global.page
 
 ```js
 beforeEach(async () => {

--- a/README.md
+++ b/README.md
@@ -321,6 +321,26 @@ it('should put test in debug mode', async () => {
 })
 ```
 
+### `global.jestPuppeteer.resetPage()`
+
+Reset global.page
+
+```js
+beforeEach(async () => {
+  await jestPuppeteer.resetPage()
+})
+```
+
+### `global.jestPuppeteer.resetBrowser()`
+
+Reset global.browser, gllobal.context, and global.page
+
+```js
+beforeEach(async () => {
+  await jestPuppeteer.resetBrowser()
+})
+```
+
 ### `jest-puppeteer.config.js`
 
 You can specify a `jest-puppeteer.config.js` at the root of the project or define a custom path using `JEST_PUPPETEER_CONFIG` environment variable.

--- a/packages/jest-environment-puppeteer/README.md
+++ b/packages/jest-environment-puppeteer/README.md
@@ -89,7 +89,7 @@ beforeEach(async () => {
 
 ### `global.jestPuppeteer.resetBrowser()`
 
-Reset global.browser, gllobal.context, and global.page
+Reset global.browser, global.context, and global.page
 
 ```js
 beforeEach(async () => {

--- a/packages/jest-environment-puppeteer/README.md
+++ b/packages/jest-environment-puppeteer/README.md
@@ -87,6 +87,16 @@ beforeEach(async () => {
 })
 ```
 
+### `global.jestPuppeteer.resetBrowser()`
+
+Reset global.browser, gllobal.context, and global.page
+
+```js
+beforeEach(async () => {
+  await jestPuppeteer.resetBrowser()
+})
+```
+
 ### `jest-puppeteer.config.js`
 
 You can specify a `jest-puppeteer.config.js` at the root of the project or define a custom path using `JEST_PUPPETEER_CONFIG` environment variable. It should export a config object or a Promise for a config object.

--- a/packages/jest-environment-puppeteer/tests/resetBrowser.test.js
+++ b/packages/jest-environment-puppeteer/tests/resetBrowser.test.js
@@ -1,0 +1,11 @@
+describe('resetBrowser', () => {
+  test('should reset browser', async () => {
+    const oldBrowser = browser
+    await jestPuppeteer.resetBrowser()
+    expect(browser).not.toBe(oldBrowser)
+    // eslint-disable-next-line no-underscore-dangle
+    expect(browser._connection._closed).toBe(false)
+    // eslint-disable-next-line no-underscore-dangle
+    expect(oldBrowser._connection._closed).toBe(true)
+  })
+})

--- a/packages/jest-environment-puppeteer/tests/resetBrowser.test.js
+++ b/packages/jest-environment-puppeteer/tests/resetBrowser.test.js
@@ -3,9 +3,7 @@ describe('resetBrowser', () => {
     const oldBrowser = browser
     await jestPuppeteer.resetBrowser()
     expect(browser).not.toBe(oldBrowser)
-    // eslint-disable-next-line no-underscore-dangle
-    expect(browser._connection._closed).toBe(false)
-    // eslint-disable-next-line no-underscore-dangle
-    expect(oldBrowser._connection._closed).toBe(true)
+    expect(browser.isConnected()).toBe(true)
+    expect(oldBrowser.isConnected()).toBe(false)
   })
 })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Add `jestPuppeteer.resetBrowser()` function to reset the `global.browser` object according to the configuration.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`global.browser` is is setup based on the configuration.

```js
this.global.browser = await puppeteer.connect({
  ...config.connect,
  ...config.launch,
  browserURL: undefined,
  browserWSEndpoint: wsEndpoint,
})
```

This will allow the browser to be reset by the user and ensure the `global.browser` object will be the same after this call as the when it was first setup.

Users can reset the `global.browser` object before each test by calling `jestPuppeteer.resetBrowser()` in a `beforeEach` function easily.

```js
beforeEach(async () => {
  await jestPuppeteer.resetBrowser()
})
```

fixes https://github.com/smooth-code/jest-puppeteer/pull/183#issuecomment-490210920

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```js
describe('resetBrowser', () => {
  test('should reset browser', async () => {
    const oldBrowser = browser
    await jestPuppeteer.resetBrowser()
    expect(browser).not.toBe(oldBrowser)
    // eslint-disable-next-line no-underscore-dangle
    expect(browser._connection._closed).toBe(false)
    // eslint-disable-next-line no-underscore-dangle
    expect(oldBrowser._connection._closed).toBe(true)
  })
})
```
