### PR TITLE
Teardown browser in watch mode.

### DIFF
--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -52,14 +52,15 @@ export async function setup(jestConfig = {}) {
 }
 
 export async function teardown(jestConfig = {}) {
+  const config = await readConfig()
+
+  if (config.connect) {
+    await browser.disconnect()
+  } else {
+    await browser.close()
+  }
+
   if (!jestConfig.watch && !jestConfig.watchAll) {
     await teardownServer()
-
-    const config = await readConfig()
-    if (config.connect) {
-      await browser.disconnect()
-    } else {
-      await browser.close()
-    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #269.

When jest is running with `--watch`, each test run creates a new browser — so we’ll want to teardown the browser to avoid memory leaks.

## Test plan

I manually tested this — not sure how to write an automated test since it involves the setup and teardown process itself.

- I started the dev server by running `PORT=4444 node server`, since the dev server is not started in `--watch` mode (see #229).
- In another terminal window, I ran `yarn test --watch`.
  - Observe that the browser is closed at the end of a test run.
  - I hit `a` to re-run all tests.
  - Observe a new browser is started, the tests are run, and it is closed.
  - Repeat forever! 