### PR TITLE
add support child frames

### DIFF
--- a/packages/expect-puppeteer/src/index.js
+++ b/packages/expect-puppeteer/src/index.js
@@ -77,6 +77,7 @@ function expectPuppeteer(actual) {
   const type = getPuppeteerType(actual)
   switch (type) {
     case 'Page':
+    case 'Frame':
       return internalExpect(actual, pageMatchers)
     case 'ElementHandle':
       return internalExpect(actual, elementHandleMatchers)

--- a/packages/expect-puppeteer/src/matchers/notToMatch.test.js
+++ b/packages/expect-puppeteer/src/matchers/notToMatch.test.js
@@ -1,9 +1,15 @@
+import { setupPage } from './setupPage'
+
 describe('not.toMatch', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should be ok if text is not in the page', async () => {
       await expect(page).not.toMatch('Nop!')
     })

--- a/packages/expect-puppeteer/src/matchers/notToMatchElement.test.js
+++ b/packages/expect-puppeteer/src/matchers/notToMatchElement.test.js
@@ -1,9 +1,15 @@
+import { setupPage } from './setupPage'
+
 describe('not.toMatchElement', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should not match using selector', async () => {
       await expect(page).not.toMatchElement('wtf')
     })

--- a/packages/expect-puppeteer/src/matchers/setupPage.js
+++ b/packages/expect-puppeteer/src/matchers/setupPage.js
@@ -1,0 +1,32 @@
+function waitForFrame(page) {
+  let fulfill
+  const promise = new Promise(resolve => {
+    fulfill = resolve
+  })
+  function checkFrame() {
+    const frame = page.frames().find(f => f.parentFrame() !== null)
+    if (frame) fulfill(frame)
+    else page.once(`frameattached`, checkFrame)
+  }
+  checkFrame()
+  return promise
+}
+
+export const setupPage = (pageType, cb) => {
+  let currentPage = page
+  beforeEach(async () => {
+    if (pageType === `Page`) {
+      cb({
+        currentPage,
+      })
+      return
+    }
+    await page.goto(
+      `http://localhost:${process.env.TEST_SERVER_PORT}/frame.html`,
+    )
+    currentPage = await waitForFrame(page)
+    cb({
+      currentPage,
+    })
+  })
+}

--- a/packages/expect-puppeteer/src/matchers/toClick.test.js
+++ b/packages/expect-puppeteer/src/matchers/toClick.test.js
@@ -1,9 +1,15 @@
+import { setupPage } from './setupPage'
+
 describe('toClick', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should click using selector', async () => {
       await expect(page).toClick('a[href="/page2.html"]')
       await page.waitForSelector('html')

--- a/packages/expect-puppeteer/src/matchers/toFill.test.js
+++ b/packages/expect-puppeteer/src/matchers/toFill.test.js
@@ -1,9 +1,15 @@
+import { setupPage } from './setupPage'
+
 describe('toFill', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should fill input', async () => {
       await expect(page).toFill('[name="firstName"]', 'James')
       const value = await page.evaluate(

--- a/packages/expect-puppeteer/src/matchers/toFillForm.test.js
+++ b/packages/expect-puppeteer/src/matchers/toFillForm.test.js
@@ -1,9 +1,15 @@
+import { setupPage } from './setupPage'
+
 describe('toFillForm', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should fill input', async () => {
       await expect(page).toFillForm('form', {
         firstName: 'James',

--- a/packages/expect-puppeteer/src/matchers/toMatch.test.js
+++ b/packages/expect-puppeteer/src/matchers/toMatch.test.js
@@ -1,9 +1,15 @@
+import { setupPage } from './setupPage'
+
 describe('toMatch', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should be ok if text is in the page', async () => {
       await expect(page).toMatch('This is home!')
     })

--- a/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
+++ b/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
@@ -1,44 +1,24 @@
-function waitForFrame(page) {
-  let fulfill
-  const promise = new Promise(resolve => {
-    fulfill = resolve
-  })
-  function checkFrame() {
-    const frame = page.frames().find(f => f.parentFrame() !== null)
-    if (frame) fulfill(frame)
-    else page.once(`frameattached`, checkFrame)
-  }
-  checkFrame()
-  return promise
-}
+import { setupPage } from './setupPage'
+
 describe('toMatchElement', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe.each(['Page', 'Frame'])('%s', type => {
-    let currentPage
-    beforeEach(async () => {
-      if (type === `Page`) {
-        currentPage = page
-        return
-      }
-      await page.goto(
-        `http://localhost:${process.env.TEST_SERVER_PORT}/frame.html`,
-      )
-      currentPage = await waitForFrame(page)
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
     })
     it('should match using selector', async () => {
-      const element = await expect(currentPage).toMatchElement(
-        'a[href="/page2.html"]',
-      )
+      const element = await expect(page).toMatchElement('a[href="/page2.html"]')
       const textContentProperty = await element.getProperty('textContent')
       const textContent = await textContentProperty.jsonValue()
       expect(textContent).toBe('Page 2')
     })
 
     it('should match using text (string)', async () => {
-      const element = await expect(currentPage).toMatchElement('a', {
+      const element = await expect(page).toMatchElement('a', {
         text: 'Page 2',
       })
       const textContentProperty = await element.getProperty('textContent')
@@ -47,7 +27,7 @@ describe('toMatchElement', () => {
     })
 
     it('should match using text (RegExp)', async () => {
-      const element = await expect(currentPage).toMatchElement('a', {
+      const element = await expect(page).toMatchElement('a', {
         text: /Page\s2/,
       })
       const textContentProperty = await element.getProperty('textContent')
@@ -59,7 +39,7 @@ describe('toMatchElement', () => {
       expect.assertions(3)
 
       try {
-        await expect(currentPage).toMatchElement('a', { text: 'Nop' })
+        await expect(page).toMatchElement('a', { text: 'Nop' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Nop") not found')
         expect(error.message).toMatch('waiting for function failed')
@@ -69,25 +49,22 @@ describe('toMatchElement', () => {
     it('should match using visible options', async () => {
       expect.assertions(11)
 
-      const normalElement = await expect(currentPage).toMatchElement(
-        '.normal',
-        {
-          visible: true,
-        },
-      )
+      const normalElement = await expect(page).toMatchElement('.normal', {
+        visible: true,
+      })
       const textContentProperty = await normalElement.getProperty('textContent')
       const textContent = await textContentProperty.jsonValue()
       expect(textContent).toBe('normal element')
 
       try {
-        await expect(currentPage).toMatchElement('.hidden', { visible: true })
+        await expect(page).toMatchElement('.hidden', { visible: true })
       } catch (error) {
         expect(error.message).toMatch('Element .hidden not found')
         expect(error.message).toMatch('waiting for function failed')
       }
 
       try {
-        await expect(currentPage).toMatchElement('.displayed', {
+        await expect(page).toMatchElement('.displayed', {
           visible: true,
         })
       } catch (error) {
@@ -96,7 +73,7 @@ describe('toMatchElement', () => {
       }
 
       try {
-        await expect(currentPage).toMatchElement('.displayedWithClassname', {
+        await expect(page).toMatchElement('.displayedWithClassname', {
           visible: true,
         })
       } catch (error) {

--- a/packages/expect-puppeteer/src/matchers/toSelect.js
+++ b/packages/expect-puppeteer/src/matchers/toSelect.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 import toMatchElement from './toMatchElement'
+import { getContext } from '../utils'
 
 function select(page, element, value) {
   return page.evaluate(
@@ -48,7 +49,7 @@ async function toSelect(instance, selector, valueOrText, options) {
   if (!option) {
     throw new Error(`Option not found "${selector}" ("${valueOrText}")`)
   }
-
+  const { page } = await getContext(instance, () => document)
   await select(page, element, option.value)
 
   // await page.select(selector, foundValue)

--- a/packages/expect-puppeteer/src/matchers/toSelect.test.js
+++ b/packages/expect-puppeteer/src/matchers/toSelect.test.js
@@ -1,9 +1,15 @@
+import { setupPage } from './setupPage'
+
 describe('toSelect', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should select an option using value', async () => {
       await expect(page).toSelect('select[name="my-select"]', 'opt1')
       const currentValue = await page.evaluate(

--- a/packages/expect-puppeteer/src/matchers/toUploadFile.test.js
+++ b/packages/expect-puppeteer/src/matchers/toUploadFile.test.js
@@ -1,11 +1,16 @@
 import path from 'path'
+import { setupPage } from './setupPage'
 
 describe('toUploadFile', () => {
   beforeEach(async () => {
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
   })
 
-  describe('Page', () => {
+  describe.each(['Page', 'Frame'])('%s', pageType => {
+    let page
+    setupPage(pageType, ({ currentPage }) => {
+      page = currentPage
+    })
     it('should upload a select file', async () => {
       await expect(page).toUploadFile(
         'input[type="file"]',

--- a/packages/expect-puppeteer/src/utils.js
+++ b/packages/expect-puppeteer/src/utils.js
@@ -3,7 +3,7 @@ export const getPuppeteerType = instance => {
     instance &&
     instance.constructor &&
     instance.constructor.name &&
-    ['Page', 'ElementHandle'].includes(instance.constructor.name) &&
+    ['Page', 'Frame', 'ElementHandle'].includes(instance.constructor.name) &&
     instance.$
   ) {
     return instance.constructor.name
@@ -16,6 +16,7 @@ export const getContext = async (instance, pageFunction) => {
   const type = getPuppeteerType(instance)
   switch (type) {
     case 'Page':
+    case 'Frame':
       return {
         page: instance,
         handle: await instance.evaluateHandle(pageFunction),

--- a/server/public/frame.html
+++ b/server/public/frame.html
@@ -1,0 +1,1 @@
+<iframe src="/index.html"></iframe>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When I pass child frame instance to expectPuppeteer, I get error `Frame is not supported`.
```
  const frame = page.frames().find(frame => frame.name() === 'myframe');
  const text = expectPuppeteer(frame).toClick('.selector');
```