### PR TITLE
Add browser config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Other options are documented in [jest-dev-server](https://github.com/smooth-code
 
 Jest Puppeteer automatically detects the best config to start Puppeteer but sometimes you may need to specify custom options. All Puppeteer [launch](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions) or [connect](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerconnectoptions) options can be specified in `jest-puppeteer.config.js` at the root of the project. Since it is JavaScript, you can use all the stuff you need, including environment.
 
+To run Puppeteer on Firefox using [puppeteer-firefox](https://github.com/GoogleChrome/puppeteer/tree/master/experimental/puppeteer-firefox), you can set `browser` to `firefox`. By default, the value is `chromium` which will use Puppeteer on Chrome.
+
 The browser context can be also specified. By default, the browser context is shared. `incognito` is available if you want more isolation between running instances. More information available in [jest-puppeteer-environment readme](https://github.com/smooth-code/jest-puppeteer/blob/master/packages/jest-environment-puppeteer/README.md)
 
 ```js
@@ -149,6 +151,7 @@ module.exports = {
     dumpio: true,
     headless: process.env.HEADLESS !== 'false',
   },
+  browser: 'chromium',
   browserContext: 'default',
 }
 ```


### PR DESCRIPTION
## Summary

Adds documentation on the `browser` config field added in PR #220.

## Test plan

Review "Configure Puppeteer" section in the README.