### PR TITLE
Increase peerDependencies to allow Puppeteer v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 8
   - 10
+  - 12
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "jest-puppeteer": "^4.2.0",
-    "puppeteer": "^1.18.1"
+    "puppeteer": "^2.0.0"
   },
   "browserslist": {
     "development": [

--- a/examples/create-react-app/yarn.lock
+++ b/examples/create-react-app/yarn.lock
@@ -4729,10 +4729,10 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
-  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+https-proxy-agent@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz#b8c286433e87602311b01c8ea34413d856a4af81"
+  integrity sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
@@ -7965,14 +7965,14 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.18.1:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.18.1.tgz#4a66f3bdab01115ededf70443ec904c99917a815"
-  integrity sha512-luUy0HPSuWPsPZ1wAp6NinE0zgetWtudf5zwZ6dHjMWfYpTQcmKveFRox7VBNhQ98OjNA9PQ9PzQyX8k/KrxTg==
+puppeteer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.0.0.tgz#0612992e29ec418e0a62c8bebe61af1a64d7ec01"
+  integrity sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"
-    https-proxy-agent "^2.2.1"
+    https-proxy-agent "^3.0.0"
     mime "^2.0.3"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lerna": "^3.15.0",
     "lint-staged": "^9.2.0",
     "prettier": "^1.18.2",
-    "puppeteer": "^1.18.1",
+    "puppeteer": "^2.0.0",
     "puppeteer-firefox": "^0.5.0"
   },
   "dependencies": {}

--- a/packages/expect-puppeteer/src/matchers/toClick.test.js
+++ b/packages/expect-puppeteer/src/matchers/toClick.test.js
@@ -12,14 +12,14 @@ describe('toClick', () => {
     })
     it('should click using selector', async () => {
       await expect(page).toClick('a[href="/page2.html"]')
-      await page.waitForSelector('html')
+      await page.waitForNavigation()
       const pathname = await page.evaluate(() => document.location.pathname)
       expect(pathname).toBe('/page2.html')
     })
 
     it('should click using text', async () => {
       await expect(page).toClick('a', { text: 'Page 2' })
-      await page.waitForSelector('html')
+      await page.waitForNavigation()
       const pathname = await page.evaluate(() => document.location.pathname)
       expect(pathname).toBe('/page2.html')
     })

--- a/packages/jest-puppeteer-preset/package.json
+++ b/packages/jest-puppeteer-preset/package.json
@@ -14,7 +14,7 @@
     "chrome-headless"
   ],
   "peerDependencies": {
-    "puppeteer": "^1.5.0"
+    "puppeteer": ">= 1.5.0 < 3"
   },
   "dependencies": {
     "expect-puppeteer": "^4.3.0",

--- a/packages/jest-puppeteer/package.json
+++ b/packages/jest-puppeteer/package.json
@@ -13,7 +13,7 @@
     "chrome-headless"
   ],
   "peerDependencies": {
-    "puppeteer": "^1.5.0"
+    "puppeteer": ">= 1.5.0 < 3"
   },
   "dependencies": {
     "expect-puppeteer": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4380,6 +4380,14 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+https-proxy-agent@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz#b8c286433e87602311b01c8ea34413d856a4af81"
+  integrity sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -7093,14 +7101,14 @@ puppeteer-firefox@^0.5.0:
     rimraf "^2.6.1"
     ws "^6.1.0"
 
-puppeteer@^1.18.1:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.18.1.tgz#4a66f3bdab01115ededf70443ec904c99917a815"
-  integrity sha512-luUy0HPSuWPsPZ1wAp6NinE0zgetWtudf5zwZ6dHjMWfYpTQcmKveFRox7VBNhQ98OjNA9PQ9PzQyX8k/KrxTg==
+puppeteer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.0.0.tgz#0612992e29ec418e0a62c8bebe61af1a64d7ec01"
+  integrity sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"
-    https-proxy-agent "^2.2.1"
+    https-proxy-agent "^3.0.0"
     mime "^2.0.3"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"


### PR DESCRIPTION
## Summary

Currently `peerDependencies` only allows `"puppeteer": "^1.5.0"`.

Puppeteer v2 was released yesterday:
https://github.com/GoogleChrome/puppeteer/releases/tag/v2.0.0

It drops support for Node.js 6, and since **jest-puppeteer** only supports Node.js 8+ anyway we can make this a non-breaking change.

## Test plan

Currently, **jest-puppeteer** runs its tests using `puppeteer@1.18.1`, so a puppeteer upgrade actually causes a breakage in `page.waitForSelector('html')` where `page` is a frame.

It seems to be hitting this bug: https://github.com/GoogleChrome/puppeteer/issues/2602

But the following quick fix resolves the issues:

**Before**
```js
await page.waitForSelector('html')
```

Which causes a protocol error:

```
• toClick › Frame › should click using text
  Protocol error (DOM.resolveNode): Node with given id does not belong to the document
```

**After**
This works instead:
```js
await page.waitForNavigation()
```

Otherwise the upgrade to Puppeteer v2 was fairly seamless.