### PR TITLE
Fix missing dependency warning

### DIFF
--- a/packages/jest-puppeteer/package.json
+++ b/packages/jest-puppeteer/package.json
@@ -13,7 +13,7 @@
     "chrome-headless"
   ],
   "peerDependencies": {
-    "puppeteer": "^1.5.0"
+    "puppeteer": "^1.5.0 || ^2.0.0"
   },
   "dependencies": {
     "expect-puppeteer": "^4.3.0",


### PR DESCRIPTION
Fix warning about missing peer dependency when use puppeteer ^2.0.0

## Summary

I faced with warning from npm when updated puppeeter to `2.0.0` to fix headless: false mode running on latest MacOS

![image](https://user-images.githubusercontent.com/13823215/67635464-440b7b80-f8d0-11e9-9195-bcf257b25536.png)


## Test plan

Install puppeteer 2.0.0 and check warnings from npm
