### PR TITLE
Fixes --watch mode server start&restarts

### DIFF
--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -10,6 +10,8 @@ import { readConfig, getPuppeteer } from './readConfig'
 
 let browser
 
+let didAlreadyRunInWatchMode = false
+
 export async function setup(jestConfig = {}) {
   const config = await readConfig()
   const puppeteer = getPuppeteer(config)
@@ -20,7 +22,11 @@ export async function setup(jestConfig = {}) {
   }
   process.env.PUPPETEER_WS_ENDPOINT = browser.wsEndpoint()
 
-  if (jestConfig.watch || jestConfig.watchAll) return
+  // If we are in watch mode, - only setupServer() once.
+  if (jestConfig.watch || jestConfig.watchAll) {
+    if (didAlreadyRunInWatchMode) return
+    didAlreadyRunInWatchMode = true
+  }
 
   if (config.server) {
     try {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fixes #229, fixes #181.

## Test plan

The `jest /tests/endtoend/** --watch` command will:
1. Start up the servers I defined in `jest-puppeteer.config.js`.
2. And, if I save some test file, - it will successfully rerun the tests (while defined servers are running) - https://github.com/smooth-code/jest-puppeteer/pull/298 PR fails this test for me.