### PR TITLE
Only call setRawMode if stdin is TTY

### DIFF
--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -60,7 +60,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
             ) {
               stdin.removeListener('data', onKeyPress)
               if (!listening) {
-                stdin.setRawMode(false)
+                if (stdin.isTTY) {
+                  stdin.setRawMode(false)
+                }
                 stdin.pause()
               }
               resolve()
@@ -68,7 +70,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
           }
           const listening = stdin.listenerCount('data') > 0
           if (!listening) {
-            stdin.setRawMode(true)
+            if (stdin.isTTY) {
+              stdin.setRawMode(true)
+            }
             stdin.resume()
             stdin.setEncoding('utf8')
           }


### PR DESCRIPTION
## Summary

`stdin.setRawMode` doesn't exist and throws if stdin is not TTY:

```
TypeError: stdin.setRawMode is not a function
  at node_modules/jest-environment-puppeteer/lib/PuppeteerEnvironment.js:82:19
  at Object.debug (node_modules/jest-environment-puppeteer/lib/PuppeteerEnvironment.js:61:16)
```