### PR TITLE
fix: require  to `puppeteer-core` as fallback

### DIFF
--- a/packages/jest-environment-puppeteer/src/readConfig.js
+++ b/packages/jest-environment-puppeteer/src/readConfig.js
@@ -51,12 +51,16 @@ export async function readConfig() {
 
 export function getPuppeteer(config) {
   switch (config.browser.toLowerCase()) {
+    /* eslint-disable global-require, import/no-dynamic-require, import/no-extraneous-dependencies, import/no-unresolved */
     case 'chromium':
-      // eslint-disable-next-line global-require, import/no-dynamic-require, import/no-extraneous-dependencies
-      return require('puppeteer')
+      try {
+        return require('puppeteer')
+      } catch (e) {
+        return require('puppeteer-core')
+      }
     case 'firefox':
-      // eslint-disable-next-line global-require, import/no-dynamic-require, import/no-extraneous-dependencies
       return require('puppeteer-firefox')
+    /* eslint-enable */
     default:
       throw new Error(
         `Error: "browser" config option is given an unsupported value: ${browser}`,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This is because sometimes we prefer `puppeteer-core` as a dependency instead of `puppeteer`.
