### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Update your Jest configuration:
 Use Puppeteer in your tests:
 
 ```js
+import 'expect-puppeteer'
+
 describe('Google', () => {
   beforeAll(async () => {
     await page.goto('https://google.com')


### PR DESCRIPTION
Added `import 'expect-puppeteer'` to the code example to make it clear where the 'toMatch' is coming from.

Running the example without this import gives a very cryptic error message.