### PR TITLE
docs: fix mismatch between comment and code in expect-puppeteer/README.md

### DIFF
--- a/packages/expect-puppeteer/README.md
+++ b/packages/expect-puppeteer/README.md
@@ -172,7 +172,7 @@ Expect an element be present in the page or element.
 // Select a row containing a text
 const row = await expect(page).toMatchElement('tr', { text: 'My row' })
 // Click on the third column link
-await expect(row).toClick('td:nth-child(2) a')
+await expect(row).toClick('td:nth-child(3) a')
 ```
 
 ### <a name="toSelect"></a>expect(instance).toSelect(selector, valueOrText)


### PR DESCRIPTION
## Summary

Fixes a very minor error in `expect-puppeteer/README.md`:  the comment in the Javascript refers to a "third column link", but the CSS refers to `td:nth-child(2)`, which is actually the second `td` child of the row. This is because the `:nth-child()` selector follows 1-based indexing according to [Mozilla's CSS documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child).