### PR TITLE
fix: add jest-environment-node as a dependency

### DIFF
--- a/packages/jest-environment-puppeteer/package.json
+++ b/packages/jest-environment-puppeteer/package.json
@@ -24,6 +24,7 @@
     "chalk": "^4.1.0",
     "cwd": "^0.10.0",
     "jest-dev-server": "^5.0.0",
+    "jest-environment-node": "^26.6.2",
     "merge-deep": "^3.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Add `jest-environment-node` as a dependency of `jest-environment-puppeteer`

fixes #396 

