### PR TITLE
fix: use Delete to clear input instead of Backspace

### DIFF
--- a/packages/expect-puppeteer/src/matchers/toFill.js
+++ b/packages/expect-puppeteer/src/matchers/toFill.js
@@ -32,7 +32,7 @@ async function toFill(instance, selector, value, options) {
     toMatchElementOptions,
   )
   await selectAll(element)
-  await element.press('Backspace')
+  await element.press('Delete')
   await element.type(value, {
     delay,
   })


### PR DESCRIPTION
fixes https://github.com/smooth-code/jest-puppeteer/pull/381#issuecomment-828420893