### PR TITLE
fix: click selector differently to prevent invisible Node

### DIFF
--- a/packages/expect-puppeteer/src/matchers/toClick.js
+++ b/packages/expect-puppeteer/src/matchers/toClick.js
@@ -5,7 +5,7 @@ async function toClick(instance, selector, options) {
   const { page } = await getContext(instance, () => document)
   const element = await toMatchElement(instance, selector, options)
 
-  await page.evaluate((el) => el.click(), element)
+  await page.evaluate((el, opts) => el.click(opts), element, options)
 }
 
 export default toClick

--- a/packages/expect-puppeteer/src/matchers/toClick.js
+++ b/packages/expect-puppeteer/src/matchers/toClick.js
@@ -3,9 +3,9 @@ import { getContext } from '../utils'
 
 async function toClick(instance, selector, options) {
   const { page } = await getContext(instance, () => document)
+  const element = await toMatchElement(instance, selector, options)
 
-  await toMatchElement(instance, selector, options)
-  await page.evaluate((selector) => document.querySelector(selector).click(), selector)
+  await page.evaluate((el) => el.click(), element)
 }
 
 export default toClick

--- a/packages/expect-puppeteer/src/matchers/toClick.js
+++ b/packages/expect-puppeteer/src/matchers/toClick.js
@@ -1,8 +1,11 @@
 import toMatchElement from './toMatchElement'
+import { getContext } from '../utils'
 
 async function toClick(instance, selector, options) {
-  const element = await toMatchElement(instance, selector, options)
-  await element.click(options)
+  const { page } = await getContext(instance, () => document)
+
+  await toMatchElement(instance, selector, options)
+  await page.evaluate((selector) => document.querySelector(selector).click(), selector)
 }
 
 export default toClick

--- a/packages/expect-puppeteer/src/matchers/toClick.test.js
+++ b/packages/expect-puppeteer/src/matchers/toClick.test.js
@@ -132,6 +132,14 @@ describe('toClick', () => {
       expect(pathname).toBe('/page2.html')
     })
 
+    it('should click an element which has a transition', async () => {
+      const body = await page.$('body')
+
+      await expect(body).toClick('.trigger-button')
+      await page.waitForSelector('#outside button')
+      await expect(body).toClick('#outside button')
+    })
+
     it('should return an error if element is not found', async () => {
       const body = await page.$('body')
       expect.assertions(2)

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -9,6 +9,14 @@
   .displayedWithClassname {
     display: none;
   }
+  #outside {
+    transform: translateX(-100%);
+    transition: .3s;
+  }
+  #outside.move-in {
+    background: red;
+    transform: translateX(0);
+  }
 </style>
 
 <body>
@@ -35,6 +43,10 @@
     <div style="display: none" class="displayed">displayed element</div>
     <div class="displayedWithClassname">displayed element</div>
     <div class="normal">normal element</div>
+    <button class="trigger-button" onclick="document.getElementById('outside').classList.add('move-in')">show outside element</button>
+    <div id="outside">
+      <button>clickable element</button>
+    </div>
   </main>
 </body>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

I basically run into an issue where `expect(page).toClick(selector)` was throwing "Node is either not visible or not an HTMLElement". I dig into this problem a little further and came to following comment: https://github.com/puppeteer/puppeteer/issues/2977#issuecomment-412807613

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The only screenshots I can provide are the "quick'n'dirty node_modules inline code changes" 🚀 

### 1. Providing the fix
![Screenshot 2021-05-05 at 13 27 15](https://user-images.githubusercontent.com/10677263/117134710-3331a500-ada6-11eb-8805-98699ff198ee.png)

### 2. Providing the old execution
![Screenshot 2021-05-05 at 13 29 51](https://user-images.githubusercontent.com/10677263/117134707-32007800-ada6-11eb-8c11-0902c361bd6b.png)

