### PR TITLE
Propagate puppeteer connection errors

### DIFF
--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -15,11 +15,22 @@ let didAlreadyRunInWatchMode = false
 export async function setup(jestConfig = {}) {
   const config = await readConfig()
   const puppeteer = getPuppeteer()
-  if (config.connect) {
-    browser = await puppeteer.connect(config.connect)
-  } else {
-    browser = await puppeteer.launch(config.launch)
+
+  try {
+    if (config.connect) {
+      browser = await puppeteer.connect(config.connect)
+    } else {
+      browser = await puppeteer.launch(config.launch)
+    }
+  } catch (e) {
+    // some puppeteer errors are non-native error objects
+    if (e && e.error) {
+      throw e.error
+    }
+
+    throw e
   }
+
   process.env.PUPPETEER_WS_ENDPOINT = browser.wsEndpoint()
 
   // If we are in watch mode, - only setupServer() once.


### PR DESCRIPTION
some puppeteer errors are non-native error objects

See also: https://github.com/smooth-code/jest-puppeteer/issues/406

## Summary

When there is a connection problem during setup, I am only seeing [object Object] displayed by Jest. This diff allows me to see the underlying error message.

Do you need me to write failure test scenarios to provide code coverage?