### PR TITLE
Browser instance per Jest worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,50 +217,50 @@ module.exports = {
 }
 ```
 
-You may want to consider using multiple projects in Jest since setting your own `setupFilesAfterEnv` and `globalSetup` can cause globals to be undefined. 
+You may want to consider using multiple projects in Jest since setting your own `setupFilesAfterEnv` and `globalSetup` can cause globals to be undefined.
 
 ```js
 module.exports = {
-	projects: [
-		{
-			displayName: 'integration',
-			preset: 'jest-puppeteer',
-			transform: {
-				'\\.tsx?$': 'babel-jest',
-				'.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
-					'jest-transform-stub'
-			},
-			moduleNameMapper: {
-				'^.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
-					'jest-transform-stub'
-			},
-			modulePathIgnorePatterns: ['.next'],
-			testMatch: [
-				'<rootDir>/src/**/__integration__/**/*.test.ts',
-				'<rootDir>/src/**/__integration__/**/*.test.tsx'
-			]
-		},
-		{
-			displayName: 'unit',
-			transform: {
-				'\\.tsx?$': 'babel-jest',
-				'.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
-					'jest-transform-stub'
-			},
-			moduleNameMapper: {
-				'^.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
-					'jest-transform-stub'
-			},
-			globalSetup: '<rootDir>/setupEnv.ts',
-			setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
-			modulePathIgnorePatterns: ['.next'],
-			testMatch: [
-				'<rootDir>/src/**/__tests_/**/*.test.ts',
-				'<rootDir>/src/**/__tests__/**/*.test.tsx'
-			]
-		}
-	]
-};
+  projects: [
+    {
+      displayName: 'integration',
+      preset: 'jest-puppeteer',
+      transform: {
+        '\\.tsx?$': 'babel-jest',
+        '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
+          'jest-transform-stub',
+      },
+      moduleNameMapper: {
+        '^.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
+          'jest-transform-stub',
+      },
+      modulePathIgnorePatterns: ['.next'],
+      testMatch: [
+        '<rootDir>/src/**/__integration__/**/*.test.ts',
+        '<rootDir>/src/**/__integration__/**/*.test.tsx',
+      ],
+    },
+    {
+      displayName: 'unit',
+      transform: {
+        '\\.tsx?$': 'babel-jest',
+        '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
+          'jest-transform-stub',
+      },
+      moduleNameMapper: {
+        '^.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
+          'jest-transform-stub',
+      },
+      globalSetup: '<rootDir>/setupEnv.ts',
+      setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
+      modulePathIgnorePatterns: ['.next'],
+      testMatch: [
+        '<rootDir>/src/**/__tests_/**/*.test.ts',
+        '<rootDir>/src/**/__tests__/**/*.test.tsx',
+      ],
+    },
+  ],
+}
 ```
 
 ### Extend `PuppeteerEnvironment`
@@ -417,6 +417,7 @@ You can specify a `jest-puppeteer.config.js` at the root of the project or defin
 - `launch` <[object]> [All Puppeteer launch options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions) can be specified in config. Since it is JavaScript, you can use all stuff you need, including environment.
 - `connect` <[object]> [All Puppeteer connect options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerconnectoptions) can be specified in config. This is an alternative to `launch` config, allowing you to connect to an already running instance of Chrome.
 - `server` <[Object]> Server options allowed by [jest-dev-server](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-dev-server)
+- `browserPerWorker` <[Boolean]> Allows to run tests for each [jest worker](https://jestjs.io/docs/cli#--maxworkersnumstring) in an individual browser.
 
 #### Example 1
 

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -12,6 +12,12 @@ const KEYS = {
   CONTROL_D: '\u0004',
   ENTER: '\r',
 }
+const FIRST_JEST_WORKER_ID = 1
+
+const getWorkerIndex = () => process.env.JEST_WORKER_ID - FIRST_JEST_WORKER_ID
+
+const getEndpointIndex = () =>
+  Math.min(+process.env.BROWSERS_COUNT - 1, getWorkerIndex())
 
 class PuppeteerEnvironment extends NodeEnvironment {
   // Jest is not available here, so we have to reverse engineer
@@ -30,7 +36,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
     const puppeteer = getPuppeteer()
     this.global.puppeteerConfig = config
 
-    const wsEndpoint = process.env.PUPPETEER_WS_ENDPOINT
+    const wsEndpoint = JSON.parse(process.env.PUPPETEER_WS_ENDPOINTS)[
+      getEndpointIndex()
+    ]
     if (!wsEndpoint) {
       throw new Error('wsEndpoint not found')
     }

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -34,10 +34,16 @@ class PuppeteerEnvironment extends NodeEnvironment {
     const config = await readConfig()
     const puppeteer = getPuppeteer()
     this.global.puppeteerConfig = config
-
-    const wsEndpoint = JSON.parse(process.env.PUPPETEER_WS_ENDPOINTS)[
-      getEndpointIndex()
-    ]
+    let wsEndpoint
+    try {
+      wsEndpoint = JSON.parse(process.env.PUPPETEER_WS_ENDPOINTS)[
+        getEndpointIndex()
+      ]
+    } catch (e) {
+      throw new Error(
+        `wsEndpoints parse error: ${e.message} in ${process.env.PUPPETEER_WS_ENDPOINTS}`,
+      )
+    }
     if (!wsEndpoint) {
       throw new Error('wsEndpoint not found')
     }

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -12,9 +12,8 @@ const KEYS = {
   CONTROL_D: '\u0004',
   ENTER: '\r',
 }
-const FIRST_JEST_WORKER_ID = 1
-
-const getWorkerIndex = () => process.env.JEST_WORKER_ID - FIRST_JEST_WORKER_ID
+// JEST_WORKER_ID starts at 1
+const getWorkerIndex = () => process.env.JEST_WORKER_ID - 1
 
 const getEndpointIndex = () =>
   Math.min(+process.env.BROWSERS_COUNT - 1, getWorkerIndex())

--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -27,14 +27,15 @@ export async function setup(jestConfig = {}) {
     config.browserPerWorker && !config.connect ? jestConfig.maxWorkers : 1
   process.env.BROWSERS_COUNT = browsersCount
 
-  const browsers2 = await Promise.all(
-    Array.from({ length: browsersCount }).map(() =>
-      openBrowser(puppeteer, config),
-    ),
+  browsers.push(
+    ...(await Promise.all(
+      Array.from({ length: browsersCount }).map(() =>
+        openBrowser(puppeteer, config),
+      ),
+    )),
   )
 
-  browsers2.forEach((browser) => wsEndpoints.push(browser.wsEndpoint()))
-  browsers.push(...browsers2)
+  browsers.forEach((browser) => wsEndpoints.push(browser.wsEndpoint()))
 
   process.env.PUPPETEER_WS_ENDPOINTS = JSON.stringify(wsEndpoints)
 


### PR DESCRIPTION
## Summary

Hello. I faced the problem described in [issue](https://github.com/smooth-code/jest-puppeteer/issues/409). 
 
In my case i cant run tests with multiple workers because the tests will affect to each other.  From different browsers i will be able to run tests from diffrent users.

I first implemented the feature system in my project. For example run tests with `--runInBand or -w 1`
![image](https://user-images.githubusercontent.com/38163651/124915726-4ca3d700-e00b-11eb-80c9-f7a0b197b844.png)

And workers count = 2 `-w 2`
![image](https://user-images.githubusercontent.com/38163651/124915875-76f59480-e00b-11eb-8e05-bd66f9e6d19e.png)

### Bug ?
If the number of workers is greater than the number of test cases in `setup.js`, more browser instances will be launched than will be used.
I tried to move the browser launch to `PuppeteerEnvironmet.js`, but there is no information about the launched browsers in` global.teardown` due to different contexts.

## Test plan
### runInBand
![image](https://user-images.githubusercontent.com/38163651/124944542-d44b0f00-e026-11eb-8484-4f305f3bbffe.png)
![image](https://user-images.githubusercontent.com/38163651/124944659-f2187400-e026-11eb-86f7-c9077d8d5aa1.png)
### maxWorkers = 2
![image](https://user-images.githubusercontent.com/38163651/124944854-18d6aa80-e027-11eb-971f-01b808e55225.png)
![image](https://user-images.githubusercontent.com/38163651/124944880-1e33f500-e027-11eb-842a-e5e512a5b464.png)
![GIF 08 07 2021 20-04-40](https://user-images.githubusercontent.com/38163651/124945817-ef6a4e80-e027-11eb-98be-f20a39e93526.gif)


