### PR TITLE
fix: Catch exceptions on browser close or disconnect during teardown

### DIFF
--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -77,9 +77,13 @@ export async function teardown(jestConfig = {}) {
   await Promise.all(
     browsers.map((browser) => {
       if (config.connect) {
-        return browser.disconnect()
+        return browser.disconnect().catch((e) => {
+          console.error(`global.js teardown: Error disconnecting browser ${e.stack}`)
+        })
       }
-      return browser.close()
+      return browser.close().catch((e) => {
+        console.error(`global.js teardown: Error closing browser ${e.stack}`)
+      })
     }),
   )
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Address #388 

## Test plan

Expect the test to close properly without `Navigation failed because browser has disconnected!` exceptions