### PR TITLE
fix: Revert catch on disconnect

### DIFF
--- a/packages/jest-environment-puppeteer/src/global.js
+++ b/packages/jest-environment-puppeteer/src/global.js
@@ -77,9 +77,7 @@ export async function teardown(jestConfig = {}) {
   await Promise.all(
     browsers.map((browser) => {
       if (config.connect) {
-        return browser.disconnect().catch((e) => {
-          console.error(`global.js teardown: Error disconnecting browser ${e.stack}`)
-        })
+        return browser.disconnect()
       }
       return browser.close().catch((e) => {
         console.error(`global.js teardown: Error closing browser ${e.stack}`)


### PR DESCRIPTION
As per comment @IljaKroonen, `disconnect()` does not return a `Promise`. Reverted modification

`disconnect()` references:

-  https://github.com/puppeteer/puppeteer/blob/943477cc1eb4b129870142873b3554737d5ef252/test/browser.spec.ts#L77
- https://github.com/puppeteer/puppeteer/blob/943477cc1eb4b129870142873b3554737d5ef252/src/common/Browser.ts#L538

