### PR TITLE
Add `funding` key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
     "packages/*"
   ],
   "repository": "https://github.com/smooth-code/jest-puppeteer",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/gregberge"
+  },
   "scripts": {
     "build": "lerna run build",
     "ci": "yarn build && yarn lint && yarn test --ci && yarn test:incognito --ci",


### PR DESCRIPTION
Hi! I'm submitting this PR because in the [simple-icons](https://github.com/simple-icons/simple-icons) project we are trying to automate as much as possible our monetary contributions to our direct dependencies, so having this metadata in the package.json files allows us to programmatically know easily how we can fund them. See [package-json#funding](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#funding).

Cheers!