### PR TITLE
Update README: add exitOnPageError flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ You can specify a `jest-puppeteer.config.js` at the root of the project or defin
 - `connect` <[object]> [All Puppeteer connect options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerconnectoptions) can be specified in config. This is an alternative to `launch` config, allowing you to connect to an already running instance of Chrome.
 - `server` <[Object]> Server options allowed by [jest-dev-server](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-dev-server)
 - `browserPerWorker` <[Boolean]> Allows to run tests for each [jest worker](https://jestjs.io/docs/cli#--maxworkersnumstring) in an individual browser.
+- `exitOnPageError` <[boolean]> Exits page on any global error message thrown. Defaults to true.
 
 #### Example 1
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This PR updates the README.md to make more visible the option `exitOnPageError`.
