### PR TITLE
[jest-dev-server] read from server's stdout to prevent buffer from filling up

### DIFF
--- a/packages/jest-dev-server/src/global.js
+++ b/packages/jest-dev-server/src/global.js
@@ -75,6 +75,8 @@ function runServer(config = {}, index = 0) {
     // eslint-disable-next-line no-console
     console.log(chalk.magentaBright('\nJest dev-server output:'))
     servers[index].stdout.pipe(serverLogPrefixer).pipe(process.stdout)
+  } else {
+    servers[index].stdout.on('data', () => {})
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Fixes problem with filling up processes buffer.
If process created by `jest-dev-server` with `debug=false` option writes something to `stdout`, it will stop responding after some time. Reading from `stdout` and doing nothing with it fixes the problem

## Test plan
Run any process with `setup` function from `jest-dev-server` with both `debug=true` and `false`. Should spawn process in both cases
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
