### PR TITLE
fix(expect-puppeteer): return proper error stack traces from matchers

### DIFF
--- a/packages/expect-puppeteer/src/index.js
+++ b/packages/expect-puppeteer/src/index.js
@@ -51,7 +51,7 @@ function createMatcher(matcher, page) {
     try {
       return await matcher(page, ...args)
     } catch (error) {
-      Error.captureStackTrace(error, createMatcher)
+      Error.captureStackTrace(error, throwingMatcher)
       throw error
     }
   }

--- a/packages/expect-puppeteer/src/matchers/notToMatch.test.js
+++ b/packages/expect-puppeteer/src/matchers/notToMatch.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('not.toMatch', () => {
@@ -22,13 +23,14 @@ describe('not.toMatch', () => {
       })
 
       it('should return an error if text is in the page', async () => {
-        expect.assertions(3)
+        expect.assertions(4)
 
         try {
           await expect(page).not.toMatch('home', options)
         } catch (error) {
           expect(error.message).toMatch('Text found "home"')
           expect(error.message).toMatch('waiting for function failed')
+          expect(error.stack).toMatch(path.resolve(__filename))
         }
       })
 
@@ -39,7 +41,7 @@ describe('not.toMatch', () => {
         })
 
         it('should return an error if text is not in the page', async () => {
-          expect.assertions(3)
+          expect.assertions(4)
           const dialogBtn = await page.$('#dialog-btn')
 
           try {
@@ -47,6 +49,7 @@ describe('not.toMatch', () => {
           } catch (error) {
             expect(error.message).toMatch('Text found "Open dialog"')
             expect(error.message).toMatch('waiting for function failed')
+            expect(error.stack).toMatch(path.resolve(__filename))
           }
         })
       })

--- a/packages/expect-puppeteer/src/matchers/notToMatchElement.test.js
+++ b/packages/expect-puppeteer/src/matchers/notToMatchElement.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('not.toMatchElement', () => {
@@ -19,13 +20,14 @@ describe('not.toMatchElement', () => {
     })
 
     it('should return an error if element is not found', async () => {
-      expect.assertions(3)
+      expect.assertions(4)
 
       try {
         await expect(page).not.toMatchElement('a', { text: 'Page 2' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Page 2") found')
         expect(error.message).toMatch('waiting for function failed')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })
@@ -43,13 +45,14 @@ describe('not.toMatchElement', () => {
 
     it('should return an error if element is not found', async () => {
       const main = await page.$('main')
-      expect.assertions(3)
+      expect.assertions(4)
 
       try {
         await expect(main).not.toMatchElement('div', { text: 'main' })
       } catch (error) {
         expect(error.message).toMatch('Element div (text: "main") found')
         expect(error.message).toMatch('waiting for function failed')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })

--- a/packages/expect-puppeteer/src/matchers/toClick.test.js
+++ b/packages/expect-puppeteer/src/matchers/toClick.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('toClick', () => {
@@ -71,17 +72,18 @@ describe('toClick', () => {
     })
 
     it('should return an error if element is not found', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(page).toClick('a', { text: 'Nop' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Nop") not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
 
     it('should return an error if element is not found with xpath selector', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(page).toClick(
@@ -90,16 +92,18 @@ describe('toClick', () => {
         )
       } catch (error) {
         expect(error.message).toMatch('Element //a (text: "Nop") not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
 
     it('should return an error if element is not found with css selector as object', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(page).toClick({ value: 'a', type: 'css' }, { text: 'Nop' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Nop") not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })
@@ -134,12 +138,13 @@ describe('toClick', () => {
 
     it('should return an error if element is not found', async () => {
       const body = await page.$('body')
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(body).toClick('a', { text: 'Nop' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Nop") not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })

--- a/packages/expect-puppeteer/src/matchers/toFill.test.js
+++ b/packages/expect-puppeteer/src/matchers/toFill.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('toFill', () => {
@@ -68,12 +69,13 @@ describe('toFill', () => {
     })
 
     it('should return an error if text is not in the page', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(page).toFill('[name="notFound"]', 'James')
       } catch (error) {
         expect(error.message).toMatch('Element [name="notFound"] not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })
@@ -101,12 +103,13 @@ describe('toFill', () => {
 
     it('should return an error if text is not in the page', async () => {
       const body = await page.$('body')
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(body).toFill('[name="notFound"]', 'James')
       } catch (error) {
         expect(error.message).toMatch('Element [name="notFound"] not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })

--- a/packages/expect-puppeteer/src/matchers/toFillForm.test.js
+++ b/packages/expect-puppeteer/src/matchers/toFillForm.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('toFillForm', () => {
@@ -26,7 +27,7 @@ describe('toFillForm', () => {
     })
 
     it('should return an error if text is not in the page', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(page).toFillForm('form[name="notFound"]', {
@@ -35,6 +36,7 @@ describe('toFillForm', () => {
         })
       } catch (error) {
         expect(error.message).toMatch('Element form[name="notFound"] not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })
@@ -58,7 +60,7 @@ describe('toFillForm', () => {
 
     it('should return an error if text is not in the page', async () => {
       const body = await page.$('body')
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(body).toFillForm('form[name="notFound"]', {
@@ -67,6 +69,7 @@ describe('toFillForm', () => {
         })
       } catch (error) {
         expect(error.message).toMatch('Element form[name="notFound"] not found')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })

--- a/packages/expect-puppeteer/src/matchers/toMatch.test.js
+++ b/packages/expect-puppeteer/src/matchers/toMatch.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('toMatch', () => {
@@ -26,13 +27,14 @@ describe('toMatch', () => {
       })
 
       it('should return an error if text is not in the page', async () => {
-        expect.assertions(3)
+        expect.assertions(4)
 
         try {
           await expect(page).toMatch('Nop', options)
         } catch (error) {
           expect(error.message).toMatch('Text not found "Nop"')
           expect(error.message).toMatch('waiting for function failed')
+          expect(error.stack).toMatch(path.resolve(__filename))
         }
       })
 
@@ -48,7 +50,7 @@ describe('toMatch', () => {
         })
 
         it('should return an error if text is not in the page', async () => {
-          expect.assertions(3)
+          expect.assertions(4)
           const dialogBtn = await page.$('#dialog-btn')
 
           try {
@@ -56,6 +58,7 @@ describe('toMatch', () => {
           } catch (error) {
             expect(error.message).toMatch('Text not found "This is home!"')
             expect(error.message).toMatch('waiting for function failed')
+            expect(error.stack).toMatch(path.resolve(__filename))
           }
         })
       })

--- a/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
+++ b/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('toMatchElement', () => {
@@ -36,13 +37,14 @@ describe('toMatchElement', () => {
     })
 
     it('should return an error if element is not found', async () => {
-      expect.assertions(3)
+      expect.assertions(4)
 
       try {
         await expect(page).toMatchElement('a', { text: 'Nop' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Nop") not found')
         expect(error.message).toMatch('waiting for function failed')
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
 

--- a/packages/expect-puppeteer/src/matchers/toSelect.test.js
+++ b/packages/expect-puppeteer/src/matchers/toSelect.test.js
@@ -1,3 +1,4 @@
+import path from "path";
 import { setupPage } from './setupPage'
 
 describe('toSelect', () => {
@@ -27,7 +28,7 @@ describe('toSelect', () => {
     })
 
     it('should return an error if option is not found', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(page).toSelect('select[name="my-select"]', 'Another world')
@@ -35,6 +36,7 @@ describe('toSelect', () => {
         expect(error.message).toMatch(
           'Option not found "select[name="my-select"]" ("Another world")',
         )
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })
@@ -60,7 +62,7 @@ describe('toSelect', () => {
 
     it('should return an error if option is not found', async () => {
       const body = await page.$('body')
-      expect.assertions(2)
+      expect.assertions(3)
 
       try {
         await expect(body).toSelect('select[name="my-select"]', 'Another world')
@@ -68,6 +70,7 @@ describe('toSelect', () => {
         expect(error.message).toMatch(
           'Option not found "select[name="my-select"]" ("Another world")',
         )
+        expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
   })


### PR DESCRIPTION
## Summary
Currently, errors thrown from matchers have a corrupt stack trace, making it impossible for the developer to tell which line of the test caused the error. 
e.g.:
![image](https://user-images.githubusercontent.com/32811901/172158600-771dd68f-8589-4f2f-bdc6-c1a247962760.png)


With the fix, the errors look good, with all the stack trace info:
![image](https://user-images.githubusercontent.com/32811901/172181357-61702dc8-3cbe-468f-b436-11793f99af8f.png)



This bug is caused by calling `Error.captureStackTrace` with the wrong 2nd parameter. Unfortunately, since `createMatcher` is not part of the stack trace, the entire stack trace is removed. `createMatcher` will never be part of the stack trace, the function that should be removed from the trace is the inner function, `throwingMatcher`.
