### PR TITLE
Update puppeteer dependency (v19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lerna": "^5.1.6",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
-    "puppeteer": "^15.3.0",
+    "puppeteer": "^19.0.0",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/expect-puppeteer/src/matchers/notToMatch.test.js
+++ b/packages/expect-puppeteer/src/matchers/notToMatch.test.js
@@ -29,7 +29,7 @@ describe('not.toMatch', () => {
           await expect(page).not.toMatch('home', options)
         } catch (error) {
           expect(error.message).toMatch('Text found "home"')
-          expect(error.message).toMatch('waiting for function failed')
+          expect(error.message).toMatch('Waiting failed')
           expect(error.stack).toMatch(path.resolve(__filename))
         }
       })
@@ -48,7 +48,7 @@ describe('not.toMatch', () => {
             await expect(dialogBtn).not.toMatch('Open dialog', options)
           } catch (error) {
             expect(error.message).toMatch('Text found "Open dialog"')
-            expect(error.message).toMatch('waiting for function failed')
+            expect(error.message).toMatch('Waiting failed')
             expect(error.stack).toMatch(path.resolve(__filename))
           }
         })

--- a/packages/expect-puppeteer/src/matchers/notToMatchElement.test.js
+++ b/packages/expect-puppeteer/src/matchers/notToMatchElement.test.js
@@ -26,7 +26,7 @@ describe('not.toMatchElement', () => {
         await expect(page).not.toMatchElement('a', { text: 'Page 2' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Page 2") found')
-        expect(error.message).toMatch('waiting for function failed')
+        expect(error.message).toMatch('Waiting failed')
         expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
@@ -51,7 +51,7 @@ describe('not.toMatchElement', () => {
         await expect(main).not.toMatchElement('div', { text: 'main' })
       } catch (error) {
         expect(error.message).toMatch('Element div (text: "main") found')
-        expect(error.message).toMatch('waiting for function failed')
+        expect(error.message).toMatch('Waiting failed')
         expect(error.stack).toMatch(path.resolve(__filename))
       }
     })

--- a/packages/expect-puppeteer/src/matchers/toMatch.test.js
+++ b/packages/expect-puppeteer/src/matchers/toMatch.test.js
@@ -33,7 +33,7 @@ describe('toMatch', () => {
           await expect(page).toMatch('Nop', options)
         } catch (error) {
           expect(error.message).toMatch('Text not found "Nop"')
-          expect(error.message).toMatch('waiting for function failed')
+          expect(error.message).toMatch('Waiting failed')
           expect(error.stack).toMatch(path.resolve(__filename))
         }
       })
@@ -57,7 +57,7 @@ describe('toMatch', () => {
             await expect(dialogBtn).toMatch('This is home!', options)
           } catch (error) {
             expect(error.message).toMatch('Text not found "This is home!"')
-            expect(error.message).toMatch('waiting for function failed')
+            expect(error.message).toMatch('Waiting failed')
             expect(error.stack).toMatch(path.resolve(__filename))
           }
         })

--- a/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
+++ b/packages/expect-puppeteer/src/matchers/toMatchElement.test.js
@@ -43,7 +43,7 @@ describe('toMatchElement', () => {
         await expect(page).toMatchElement('a', { text: 'Nop' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Nop") not found')
-        expect(error.message).toMatch('waiting for function failed')
+        expect(error.message).toMatch('Waiting failed')
         expect(error.stack).toMatch(path.resolve(__filename))
       }
     })
@@ -62,7 +62,7 @@ describe('toMatchElement', () => {
         await expect(page).toMatchElement('.hidden', { visible: true })
       } catch (error) {
         expect(error.message).toMatch('Element .hidden not found')
-        expect(error.message).toMatch('waiting for function failed')
+        expect(error.message).toMatch('Waiting failed')
       }
 
       try {
@@ -71,7 +71,7 @@ describe('toMatchElement', () => {
         })
       } catch (error) {
         expect(error.message).toMatch('Element .displayed not found')
-        expect(error.message).toMatch('waiting for function failed')
+        expect(error.message).toMatch('Waiting failed')
       }
 
       try {
@@ -82,7 +82,7 @@ describe('toMatchElement', () => {
         expect(error.message).toMatch(
           'Element .displayedWithClassname not found',
         )
-        expect(error.message).toMatch('waiting for function failed')
+        expect(error.message).toMatch('Waiting failed')
       }
     })
   })
@@ -124,7 +124,7 @@ describe('toMatchElement', () => {
         await expect(main).toMatchElement('a', { text: 'Page 2' })
       } catch (error) {
         expect(error.message).toMatch('Element a (text: "Page 2") not found')
-        expect(error.message).toMatch('waiting for function failed')
+        expect(error.message).toMatch('Waiting failed')
       }
     })
   })

--- a/packages/expect-puppeteer/src/utils.js
+++ b/packages/expect-puppeteer/src/utils.js
@@ -3,10 +3,10 @@ export const getPuppeteerType = (instance) => {
     instance &&
     instance.constructor &&
     instance.constructor.name &&
-    ['Page', 'Frame', 'ElementHandle'].includes(instance.constructor.name) &&
+    ['Page', 'CDPPage', 'Frame', 'ElementHandle'].includes(instance.constructor.name) &&
     instance.$
   ) {
-    return instance.constructor.name
+    return instance.constructor.name === 'CDPPage' ? 'Page' : instance.constructor.name
   }
 
   return null
@@ -22,9 +22,8 @@ export const getContext = async (instance, pageFunction) => {
         handle: await instance.evaluateHandle(pageFunction),
       }
     case 'ElementHandle': {
-      const executionContext = await instance.executionContext()
       return {
-        page: await executionContext.frame(),
+        page: instance.frame,
         handle: instance,
       }
     }


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19bFn1bsaOVGNSVxfC7y5TSe1fhtCDUMgM%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=QmAv40o)
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

We wanted to update `pupeeteer` dependency in one of our projects where we also use `jest-pupeeteer` and we are finding unexpected errors in our tests, for instance when using `toWatch` matcher both in page and elements level.
Example: 
![image](https://user-images.githubusercontent.com/97907068/196967953-a396bf67-0b79-441f-bca7-c697f3ba650f.png)

It seems `pupeeteer` changed some APIs used from this package so directly updating does not work.
I tried to update the code where I found the problems but there still exist one test I'm not able to fix.
Perhaps others with more context in the project might know how.

## Test plan

Currently, one of the tests is failing.

![image](https://user-images.githubusercontent.com/97907068/196968741-06295c69-a1ab-4e52-955a-a35b679345b0.png)

