### PR TITLE
Add option `runBeforeUnloadOnClose`

### DIFF
--- a/packages/jest-environment-puppeteer/README.md
+++ b/packages/jest-environment-puppeteer/README.md
@@ -107,6 +107,7 @@ You can specify a `jest-puppeteer.config.js` at the root of the project or defin
   - `default` Each test starts a tab, so all tests share the same context.
   - `incognito` Each tests starts an incognito window, so all tests have a separate, isolated context. Useful when running tests that could interfere with one another. (_Example: testing multiple users on the same app at once with login, transactions, etc._)
 - `exitOnPageError` <[boolean]> Exits page on any global error message thrown. Defaults to `true`.
+- `runBeforeUnloadOnClose` <[boolean]> Run `page.close()` with `{ runBeforeUnload: true }` when tests finish, see [`page.close`](https://pptr.dev/api/puppeteer.page.close/)
 - `server` <[Object]> Server options allowed by [jest-dev-server](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-dev-server)
 
 #### Example 1

--- a/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
+++ b/packages/jest-environment-puppeteer/src/PuppeteerEnvironment.js
@@ -95,7 +95,11 @@ class PuppeteerEnvironment extends NodeEnvironment {
       resetPage: async () => {
         if (this.global.page) {
           this.global.page.removeListener('pageerror', handleError)
-          await this.global.page.close()
+          if (this.global.puppeteerConfig.runBeforeUnloadOnClose) {
+            await this.global.page.close({ runBeforeUnload: true })
+          } else {
+            await this.global.page.close()
+          }
         }
 
         this.global.page = await this.global.context.newPage()
@@ -110,7 +114,11 @@ class PuppeteerEnvironment extends NodeEnvironment {
         if (config.browserContext === 'incognito' && this.global.context) {
           await this.global.context.close()
         } else if (this.global.page) {
-          await this.global.page.close()
+          if (this.global.puppeteerConfig.runBeforeUnloadOnClose) {
+            await this.global.page.close({ runBeforeUnload: true })
+          } else {
+            await this.global.page.close()
+          }
         }
         this.global.page = null
 
@@ -162,7 +170,11 @@ class PuppeteerEnvironment extends NodeEnvironment {
         await context.close()
       }
     } else if (page) {
-      await page.close()
+      if (puppeteerConfig.runBeforeUnloadOnClose) {
+        await page.close({ runBeforeUnload: true })
+      } else {
+        await page.close()
+      }
     }
 
     if (browser) {

--- a/packages/jest-environment-puppeteer/tests/runBeforeUnload.test.js
+++ b/packages/jest-environment-puppeteer/tests/runBeforeUnload.test.js
@@ -1,0 +1,18 @@
+describe('runBeforeUnload', () => {
+  it('shouldn’t call page.close with runBeforeUnload by default', async () => {
+    const closeSpy = jest.spyOn(page, 'close')
+    await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
+    await jestPuppeteer.resetPage()
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledWith()
+  })
+
+  it('should call page.close({ runBeforeUnload: true }) when runBeforeUnloadOnClose is set to true', async () => {
+    const closeSpy = jest.spyOn(page, 'close')
+    global.puppeteerConfig.runBeforeUnloadOnClose = true
+    await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)
+    await jestPuppeteer.resetPage()
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledWith({ runBeforeUnload: true })
+  })
+})

--- a/packages/jest-environment-puppeteer/tests/runBeforeUnloadOnClose.test.js
+++ b/packages/jest-environment-puppeteer/tests/runBeforeUnloadOnClose.test.js
@@ -1,4 +1,4 @@
-describe('runBeforeUnload', () => {
+describe('runBeforeUnloadOnClose', () => {
   it('shouldn’t call page.close with runBeforeUnload by default', async () => {
     const closeSpy = jest.spyOn(page, 'close')
     await page.goto(`http://localhost:${process.env.TEST_SERVER_PORT}`)


### PR DESCRIPTION
## Summary

Closes https://github.com/smooth-code/jest-puppeteer/issues/362

Introduce a new option `runBeforeUnloadOnClose` that controls whether or not `page.close` should be called with `runBeforeUnload: true`

## Test plan

Tests were added:

<img width="527" alt="image" src="https://user-images.githubusercontent.com/22725671/204025308-90971a45-6d64-41be-80d8-71e3a2a7a4aa.png">

