### PR TITLE
fix(jest-dev-server): properly detect if port is used, using both config.port and config.host options.

### DIFF
--- a/packages/jest-dev-server/src/index.ts
+++ b/packages/jest-dev-server/src/index.ts
@@ -165,7 +165,7 @@ const checkIsPortBusy = async (config: Config): Promise<boolean> => {
       .once("listening", () => {
         server.once("close", () => resolve(false)).close();
       })
-      .listen(config.port);
+      .listen(config.port, config.host);
   });
 };
 


### PR DESCRIPTION

## Summary

Fixes Issue #555.
It has been provided a thorough description and analysis of the problem in that GH issue.

## Test plan

Executed locally and the issue reported above stopped reproducing, everything works as expected.