### PR TITLE
Enable Support for WebDriver-Bidi in Firefox

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -9,6 +9,7 @@ process.env.TEST_SERVER_PORT = port;
  */
 const jestPuppeteerConfig = {
   launch: {
+    browser: process.env.BROWSER || "chrome",
     headless: "new",
     args: ["--no-sandbox"],
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "prettier --check . && eslint .",
     "test": "jest --runInBand",
     "test:incognito": "cross-env INCOGNITO=true jest --runInBand",
+    "test:firefox": "cross-env BROWSER=firefox jest --runInBand",
     "release": "npm run build && lerna publish --conventional-commits && npx conventional-github-releaser -p angular",
     "release-canary": "npm run build && lerna publish --canary --dist-tag canary"
   },

--- a/packages/jest-environment-puppeteer/src/browsers.ts
+++ b/packages/jest-environment-puppeteer/src/browsers.ts
@@ -100,6 +100,7 @@ export const startBrowsers = async ({
   );
   const wsEndpoints = browsers.map((browser) => browser.wsEndpoint());
   saveWsEndpoints(wsEndpoints);
+  browsers.forEach((browser) => browser.disconnect());
   return browsers;
 };
 
@@ -107,9 +108,33 @@ export const closeBrowsers = async (
   config: JestPuppeteerConfig,
   browsers: Browser[],
 ) => {
-  await Promise.all(
-    browsers.map(async (browser) => closeBrowser(config, browser)),
-  );
+  if (config.connect) {
+    await Promise.all(
+      browsers.map(async (browser) => closeBrowser(config, browser)),
+    );
+  }
+
+  const closeRequests: Promise<void>[] = [];
+  const puppeteer = getPuppeteer();
+  const wsEndpoints = readWsEndpoints();
+  while (wsEndpoints.length) {
+    const wsEndpoint = wsEndpoints.pop()!;
+    closeRequests.push(
+      puppeteer
+        .connect({
+          ...(config.launch?.browser === "firefox" && {
+            protocol: "webDriverBiDi",
+          }),
+          ...config.connect,
+          ...config.launch,
+          browserURL: undefined,
+          browserWSEndpoint: wsEndpoint,
+        })
+        .then((browser) => browser.close()),
+    );
+  }
+  await Promise.all(closeRequests);
+  saveWsEndpoints([]);
 };
 
 const getWorkerWsEndpoint = (): string => {
@@ -128,6 +153,7 @@ export const connectBrowserFromWorker = async (
   const wsEndpoint = getWorkerWsEndpoint();
   const puppeteer = getPuppeteer();
   return puppeteer.connect({
+    ...(config.launch?.browser === "firefox" && { protocol: "webDriverBiDi" }),
     ...config.connect,
     ...config.launch,
     browserURL: undefined,


### PR DESCRIPTION
## Summary

Closes https://github.com/argos-ci/jest-puppeteer/issues/609.

Support for CDP was removed in Firefox v141, leaving WebDriver BiDi as the only supported automation protocol. However, [Firefox currently does not support multiple concurrent WebDriver BiDi sessions](https://bugzilla.mozilla.org/show_bug.cgi?id=1862018).

To work around this limitation, the setup has been modified to:
- Launch the browser once
- Record the `wsEndpoint`
- Immediately disconnect

Subsequent access to the browser is handled via `puppeteer.connect()` using the saved `wsEndpoint`, ensuring only a single active connection at any time.

> **Note:**  I made the minimal changes necessary in order to re-enable support for Firefox.  This PR could likely be cleaned up further.

## Test Plan

Firefox-specific tests were added and can be run via the `test:firefox` npm script.

> **Note:** These tests only pass when using `jest-environment-puppeteer`.  
> `expect-puppeteer` is currently incompatible with WebDriver BiDi and supports only CDP, as noted in [issue #614](https://github.com/argos-ci/jest-puppeteer/issues/614).
